### PR TITLE
Fix relatedOperations list

### DIFF
--- a/service/rpc/rosetta_transforms.go
+++ b/service/rpc/rosetta_transforms.go
@@ -137,11 +137,8 @@ func OperationsFromAnalyzer(iop *analyzer.Operation, baseIndex int64) []*rosetta
 	operations := make([]*rosettaTypes.Operation, len(iop.Changes))
 	for i, change := range iop.Changes {
 		var relatedOps []*rosettaTypes.OperationIdentifier
-		if opIndex > 0 {
-			relatedOps = make([]*rosettaTypes.OperationIdentifier, opIndex)
-			for i := int64(0); i < opIndex; i++ {
-				relatedOps[i] = NewOperationIdentifier(i)
-			}
+		for i := baseIndex; i < opIndex; i++ {
+			relatedOps = append(relatedOps, NewOperationIdentifier(i))
 		}
 
 		operations[i] = &rosettaTypes.Operation{


### PR DESCRIPTION
Bug: Related ops were ALL previous operations, instead of just
the ones that are related.