### PR TITLE
Fixes static-nodes path 

### DIFF
--- a/service/geth/geth.go
+++ b/service/geth/geth.go
@@ -223,7 +223,7 @@ func (gopts GethOpts) IpcFile() string {
 }
 
 func (gopts GethOpts) StaticNodesFile() string {
-	return filepath.Join(gopts.Datadir, "/Celo/static-nodes.json")
+	return filepath.Join(gopts.Datadir, "/celo/static-nodes.json")
 }
 
 func chainParamsFromGenesisFile(genesisPath string) *celo.ChainParameters {

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.5.2"
+	MiddlewareVersion = "0.5.3"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
This fixes the issue around running Rosetta in a linux environment. Mac OS is case insensitive, which is why we never noticed this locally. 