### PR TITLE
Improve cmd line args + configurable geth options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,12 +74,18 @@ RUN echo $COMMIT_SHA > /version.txt
 RUN mkdir /data
 RUN mkdir /logs
 RUN mkdir -p /var
+
 EXPOSE 8080/tcp
-ENV ROSETTA_LOGS="/logs/celo.log"
-ENV ROSETTA_IPCPATH="/var/geth.ipc"
+EXPOSE 30503/tcp
+EXPOSE 30503/udp
+
 ENV ROSETTA_DATADIR="/data"
-ENV ROSETTA_GETH="/usr/local/bin/geth"
-ENV ROSETTA_GENESIS="/data/genesis.json"
+ENV ROSETTA_RPC_PORT="8080"
+ENV ROSETTA_GETH_LOGFILE="/logs/celo.log"
+ENV ROSETTA_GETH_IPCPATH="/var/geth.ipc"
+ENV ROSETTA_GETH_BINARY="/usr/local/bin/geth"
+ENV ROSETTA_GETH_GENESIS="/data/genesis.json"
+
 ENTRYPOINT ["/usr/local/bin/rosetta"]
 CMD ["run"]
 

--- a/README.md
+++ b/README.md
@@ -37,38 +37,61 @@ Rosetta exposes the following endpoints:
 
 For an understanding of inputs & outputs check [servicer.go](./service/rpc/servicer.go)
 
+## Command line arguments
+
+The main command is `rosetta run`, whose arguments are:
+
+```
+Usage:
+  rosetta run [flags]
+
+Flags:
+      --datadir string            datadir to use
+      --geth.binary string        Path to the celo-blockchain binary
+      --geth.bootnodes string     Bootnodes to use (separated by ,)
+      --geth.genesis string       path to the genesis.json
+      --geth.ipcpath string       Path to the geth ipc file
+      --geth.logfile string       Path to logs file
+      --geth.publicip string      Public Ip to configure geth (sometimes required for discovery)
+      --geth.staticnodes string   StaticNode to use (separated by ,)
+      --geth.verbosity string     Geth log verbosity (number between [1-5])
+  -h, --help                      help for run
+      --rpc.address string        Listening address for http server
+      --rpc.port uint             Listening port for http server (default 8080)
+      --rpc.reqTimeout duration   Timeout when serving a request (default 25s)
+```
+
+Every argument can be defined using environment variables using `ROSETTA_` prefix; and replacing `.` for `_`; for example:
+```
+ROSETTA_DATADIR="/my/dir"
+ROSETTA_GETH_GENESIS="/path/to/genesis.json"
+``` 
+
 ## Running Rosetta Docker Image
 
 Rosetta is released as a docker image: `us.gcr.io/celo-testnet/rosetta`. All version can be found on the [registry page](https://us.gcr.io/celo-testnet/rosetta)
 
 Within the docker image, we pack `rosetta` binary and also `geth` binary from celo-blockchain. Rosetta will run both.
 
-### Configuration
-
-The necessary parameters to run Celo Rosetta are:
-
- * `genesis.json` for the target network (can be found by `curl 'https://storage.googleapis.com/genesis_blocks/baklava' > genesis.json`)
- * `staticNode` enodeURL. Rosetta will directly peer to the list of staticNode provided (it doens't run discovery protocol for the moment).
-    This node can be any you have access to. For a public list check `https://storage.cloud.google.com/static_nodes/baklava`
+To run Rosetta using the docker container, the following options must be configured:
+  * `genesis.json` for the target network (can be found by `curl 'https://storage.googleapis.com/genesis_blocks/baklava' > genesis.json`)
+  * `staticNodes` or `bootnodes`.
+    * With `staticNodes` Rosetta will directly peer to the list of staticNode provided. This node can be any you have access to. For a public list check `https://storage.cloud.google.com/static_nodes/baklava`
 
 Additionaly, it needs a data directory for the geth datadir & rosetta.db
 
-### Run
-
 To run Celo Rosetta:
-
 
 ```bash
 # Use the last release
-export RELEASE="0.1.2"
+export RELEASE="0.5.4" #might be outdated
 # folder for rosetta to use as data directory (saves rosetta.db & celo-blockchain datadir)
 export DATADIR="/var/rosetta"
-# enode for a known address to peer
-export STATICNODE="enode://33ac194052ccd10ce54101c8340dbbe7831de02a3e7dcbca7fd35832ff8c53a72fd75e57ce8c8e73a0ace650dc2c2ec1e36f0440e904bc20a3cf5927f2323e85@34.83.199.225:30303"
 docker pull us.gcr.io/celo-testnet/rosetta:$RELEASE
 docker run --name rosetta --rm \
   -v "${DATADIR}:/data" \
   -p 8080:8080 \
+  -e ROSETTA_GETH_STATICNODES="enode://33ac194052ccd10ce54101c8340dbbe7831de02a3e7dcbca7fd35832ff8c53a72fd75e57ce8c8e73a0ace650dc2c2ec1e36f0440e904bc20a3cf5927f2323e85@34.83.199.225:30303"
   us.gcr.io/celo-testnet/rosetta:$RELEASE \
   run --staticNode $STATICNODE
 ```
@@ -137,9 +160,9 @@ Prerequisites:
 
 ```bash
 go run main.go run \
-  --genesis ./envs/rc1/genesis.json \
-  --geth ../celo-blockchain/build/bin/geth \
-  --staticNode "enode://5e0f4e3aaa096e2a2db76622b335cab4d3224d08d16cb11e8855a3a5f30c19d35d81a74b21271562e459495ab203c2f3a5a5747a83eb53ba046aeeb09aa240ff@34.83.110.24:30303"
+  --geth.genesis ./envs/rc1/genesis.json \
+  --geth.binary ../celo-blockchain/build/bin/geth \
+  --geth.staticnodes "enode://5e0f4e3aaa096e2a2db76622b335cab4d3224d08d16cb11e8855a3a5f30c19d35d81a74b21271562e459495ab203c2f3a5a5747a83eb53ba046aeeb09aa240ff@34.83.110.24:30303"
   --datadir "./envs/rc1"
 ```
 
@@ -153,24 +176,8 @@ Prerequisites:
 
 ```bash
 go run main.go run \
-  --genesis ./envs/alfajores/genesis.json \
-  --geth ../celo-blockchain/build/bin/geth \
-  --staticNode "enode://05977f6b7d3e16a99d27b714f8a029a006e41ec7732167d373dd920d31f72b3a1776650798d8763560854369d36867e9564dad13b4b60a90c347feeb491d83a9@34.83.42.50:30303"
+  --geth.genesis ./envs/alfajores/genesis.json \
+  --geth.binary ../celo-blockchain/build/bin/geth \
+  --geth.staticnodes "enode://05977f6b7d3e16a99d27b714f8a029a006e41ec7732167d373dd920d31f72b3a1776650798d8763560854369d36867e9564dad13b4b60a90c347feeb491d83a9@34.83.42.50:30303"
   --datadir "./envs/alfajores"
-```
-
-#### Running on RC0:
-
-Prerequisites:
-  * Download `celo-monorepo` branch `rc0` and `yarn && yarn build`
-  * Download `celo-blockchain` branch `mc/rosetta-rc0` and `make all`
-  * Download `rosetta` branch `rc0` update go.mod and `make gen-contracts && make all`
-  * Run `make rc0-env` to create an empty datadir with the genesis block
-
-```bash
-go run main.go run \
-  --genesis ./envs/rc0/genesis.json \
-  --geth ../celo-blockchain/build/bin/geth \
-  --staticNode "enode://33ac194052ccd10ce54101c8340dbbe7831de02a3e7dcbca7fd35832ff8c53a72fd75e57ce8c8e73a0ace650dc2c2ec1e36f0440e904bc20a3cf5927f2323e85@34.83.199.225:30303" \
-  --datadir "./envs/rc0"
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,8 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -44,40 +46,8 @@ func Execute() {
 }
 
 func init() {
-	viper.SetEnvPrefix("ROSETTA")
-	viper.AutomaticEnv() // read in environment variables that match
-
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
-
 	RootCmd.AddCommand(cli.CliCmd)
-
-	cobra.OnInitialize(initConfig)
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	// if cfgFile != "" {
-	// 	// Use config file from the flag.
-	// 	viper.SetConfigFile(cfgFile)
-	// } else {
-	// 	// Find home directory.
-	// 	home, err := homedir.Dir()
-	// 	if err != nil {
-	// 		fmt.Println(err)
-	// 		os.Exit(1)
-	// 	}
-
-	// fmt.Println("datadir=", viper.Get("datadir"))
-
-	// 	// Search config in home directory with name ".rosetta" (without extension).
-	// 	viper.AddConfigPath(home)
-	// 	viper.SetConfigName(".rosetta")
-	// }
-
-	// // If a config file is found, read it in.
-	// if err := viper.ReadInConfig(); err == nil {
-	// 	fmt.Println("Using config file:", viper.ConfigFileUsed())
-	// }
+	RootCmd.AddCommand(serveCmd)
 }
 
 func exitOnMissingConfig(cmd *cobra.Command, configKey string) {
@@ -86,4 +56,10 @@ func exitOnMissingConfig(cmd *cobra.Command, configKey string) {
 		cmd.Printf("Missing required config: %s\n", configKey)
 		os.Exit(1)
 	}
+}
+
+func printUsageAndExit(cmd *cobra.Command, msg string) {
+	cmd.Println(cmd.UsageString())
+	cmd.Println(msg)
+	os.Exit(1)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/celo-org/rosetta/celo/client"
@@ -41,51 +42,46 @@ var serveCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Start rosetta server",
 	Args:  cobra.NoArgs,
-	Run:   runRunCmd,
-}
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		viper.SetEnvPrefix("ROSETTA")
+		viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+		viper.AutomaticEnv()
 
-var rosettaRpcConfig rpc.RosettaServerConfig
+		return viper.BindPFlags(cmd.Flags())
+	},
+	Run: runRunCmd,
+}
 
 type ConfigPaths string
 
-var staticNodes []string
-
 func init() {
-	RootCmd.AddCommand(serveCmd)
-
 	flagSet := serveCmd.Flags()
 
 	// Common Flags
 	flagSet.String("datadir", "", "datadir to use")
-	utils.ExitOnError(viper.BindPFlag("datadir", flagSet.Lookup("datadir")))
 	utils.ExitOnError(serveCmd.MarkFlagDirname("datadir"))
 
-	flagSet.String("logs", "", "Path to logs file")
-	utils.ExitOnError(viper.BindPFlag("logs", flagSet.Lookup("logs")))
-	utils.ExitOnError(serveCmd.MarkFlagDirname("logs"))
-
 	// RPC Service Flags
-	flagSet.UintVar(&rosettaRpcConfig.Port, "port", 8080, "Listening port for http server")
-	flagSet.StringVar(&rosettaRpcConfig.Interface, "address", "", "Listening address for http server")
-	flagSet.DurationVar(&rosettaRpcConfig.RequestTimeout, "reqTimeout", 25*time.Second, "Timeout when serving a request")
+	flagSet.Uint("rpc.port", 8080, "Listening port for http server")
+	flagSet.String("rpc.address", "", "Listening address for http server")
+	flagSet.Duration("rpc.reqTimeout", 25*time.Second, "Timeout when serving a request")
 
 	// Geth Service Flags
-	flagSet.String("geth", "", "Path to the celo-blockchain binary")
-	utils.ExitOnError(viper.BindPFlag("geth", flagSet.Lookup("geth")))
-	utils.ExitOnError(serveCmd.MarkFlagFilename("geth"))
+	flagSet.String("geth.binary", "", "Path to the celo-blockchain binary")
+	utils.ExitOnError(serveCmd.MarkFlagFilename("geth.binary"))
 
-	flagSet.String("ipcpath", "", "Path to the geth ipc file")
-	utils.ExitOnError(viper.BindPFlag("ipcpath", flagSet.Lookup("ipcpath")))
-	utils.ExitOnError(serveCmd.MarkFlagFilename("ipcpath"))
+	flagSet.String("geth.logfile", "", "Path to logs file")
+	utils.ExitOnError(serveCmd.MarkFlagDirname("geth.logfile"))
 
-	flagSet.String("genesis", "", "path to the genesis.json")
-	utils.ExitOnError(viper.BindPFlag("genesis", flagSet.Lookup("genesis")))
-	utils.ExitOnError(serveCmd.MarkFlagFilename("genesis", "json"))
+	flagSet.String("geth.ipcpath", "", "Path to the geth ipc file")
+	utils.ExitOnError(serveCmd.MarkFlagFilename("geth.ipcpath"))
 
-	flagSet.StringArrayVar(&staticNodes, "staticNode", []string{}, "StaticNode to use (can be repeated many times")
-	utils.ExitOnError(serveCmd.MarkFlagRequired("staticNode"))
+	flagSet.String("geth.genesis", "", "path to the genesis.json")
+	utils.ExitOnError(serveCmd.MarkFlagFilename("geth.genesis", "json"))
 
-	// Monitor Service Flags
+	flagSet.String("geth.staticnodes", "", "StaticNode to use (separated by ,)")
+	flagSet.String("geth.bootnodes", "", "Bootnodes to use (separated by ,)")
+	flagSet.String("geth.verbosity", "", "Geth log verbosity (number between [1-5])")
 
 }
 
@@ -94,34 +90,52 @@ func getDatadir(cmd *cobra.Command) string {
 
 	absDatadir, err := filepath.Abs(viper.GetString("datadir"))
 	if err != nil {
-		log.Crit("Can't resolve datadir path", "datadir", absDatadir, "err", err)
+		printUsageAndExit(cmd, fmt.Sprintf("Can't resolve datadir path: %s, error: %s", absDatadir, err))
 	}
 
 	isDir, err := fileutils.IsDirectory(absDatadir)
 	if err != nil {
-		log.Crit("Can't access datadir", "datadir", absDatadir, "err", err)
+		printUsageAndExit(cmd, fmt.Sprintf("Can't access datadir path: %s, error: %s", absDatadir, err))
 	} else if !isDir {
-		log.Crit("Datadir is not a directory", "datadir", absDatadir)
+		printUsageAndExit(cmd, fmt.Sprintf("Datadir is not a directory: %s, error: %s", absDatadir, err))
 	}
 
 	return absDatadir
 }
 
-func runRunCmd(cmd *cobra.Command, args []string) {
-	datadir := getDatadir(cmd)
-	exitOnMissingConfig(cmd, "geth")
-	exitOnMissingConfig(cmd, "genesis")
-
-	gethOpts := &geth.GethOpts{
-		GethBinary:  viper.GetString("geth"),
-		GenesisPath: viper.GetString("genesis"),
+func readGethOption(cmd *cobra.Command, datadir string) *geth.GethOpts {
+	opts := &geth.GethOpts{
+		GethBinary:  viper.GetString("geth.binary"),
+		GenesisPath: viper.GetString("geth.genesis"),
 		Datadir:     filepath.Join(datadir, "celo"),
-		LogsPath:    viper.GetString("logs"),
-		IpcPath:     viper.GetString("ipcpath"),
-		StaticNodes: staticNodes,
+		LogsPath:    viper.GetString("geth.logfile"),
+		IpcPath:     viper.GetString("geth.ipcpath"),
+		Bootnodes:   viper.GetString("geth.bootnodes"),
+		Verbosity:   viper.GetString("geth.verbosity"),
+		StaticNodes: viper.GetString("geth.staticnodes"),
 	}
 
+	if opts.GethBinary == "" {
+		printUsageAndExit(cmd, "Missing config option for 'geth.binary'")
+	}
+	if opts.GenesisPath == "" {
+		printUsageAndExit(cmd, "Missing config option for 'geth.gensis'")
+	}
+
+	return opts
+}
+
+func runRunCmd(cmd *cobra.Command, args []string) {
+	datadir := getDatadir(cmd)
+	gethOpts := readGethOption(cmd, datadir)
 	sqlitePath := filepath.Join(datadir, "rosetta.db")
+
+	rpcConfig :=
+		&rpc.RosettaServerConfig{
+			Interface:      viper.GetString("rpc.address"),
+			Port:           viper.GetUint("rpc.port"),
+			RequestTimeout: viper.GetDuration("rpc.reqTimeout"),
+		}
 
 	// TODO - create context that encapsulate Stop on Signal behaviour
 	srvCtx, stopServices := context.WithCancel(context.Background())
@@ -133,13 +147,13 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 		stopServices()
 	}()
 
-	if err := runAllServices(srvCtx, sqlitePath, gethOpts); err != nil {
+	if err := runAllServices(srvCtx, sqlitePath, gethOpts, rpcConfig); err != nil {
 		log.Error("Rosetta run failed", "err", err)
 		os.Exit(1)
 	}
 }
 
-func runAllServices(ctx context.Context, sqlitePath string, gethOpts *geth.GethOpts) error {
+func runAllServices(ctx context.Context, sqlitePath string, gethOpts *geth.GethOpts, rpcConfig *rpc.RosettaServerConfig) error {
 	ctx, stopServices := context.WithCancel(ctx)
 	defer stopServices()
 
@@ -158,7 +172,7 @@ func runAllServices(ctx context.Context, sqlitePath string, gethOpts *geth.GethO
 
 	sm.Add(gethSrv)
 
-	gethStarted := utils.WaitUntil(500*time.Millisecond, 30*time.Second, func() bool {
+	gethStarted := utils.WaitUntil(500*time.Millisecond, 5*time.Minute, func() bool {
 		return fileutils.FileExists(gethSrv.IpcFilePath())
 	})
 
@@ -174,7 +188,7 @@ func runAllServices(ctx context.Context, sqlitePath string, gethOpts *geth.GethO
 		return fmt.Errorf("can't connect to geth: %w", err)
 	}
 
-	rpcService, err := rpc.NewRosettaServer(cc, celoStore, &rosettaRpcConfig, chainParams)
+	rpcService, err := rpc.NewRosettaServer(cc, celoStore, rpcConfig, chainParams)
 	if err != nil {
 		return fmt.Errorf("can't create rpc server: %w", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -82,6 +82,7 @@ func init() {
 	flagSet.String("geth.staticnodes", "", "StaticNode to use (separated by ,)")
 	flagSet.String("geth.bootnodes", "", "Bootnodes to use (separated by ,)")
 	flagSet.String("geth.verbosity", "", "Geth log verbosity (number between [1-5])")
+	flagSet.String("geth.publicip", "", "Public Ip to configure geth (sometimes required for discovery)")
 
 }
 
@@ -113,6 +114,7 @@ func readGethOption(cmd *cobra.Command, datadir string) *geth.GethOpts {
 		Bootnodes:   viper.GetString("geth.bootnodes"),
 		Verbosity:   viper.GetString("geth.verbosity"),
 		StaticNodes: viper.GetString("geth.staticnodes"),
+		PublicIp:    viper.GetString("geth.publicip"),
 	}
 
 	if opts.GethBinary == "" {
@@ -120,6 +122,10 @@ func readGethOption(cmd *cobra.Command, datadir string) *geth.GethOpts {
 	}
 	if opts.GenesisPath == "" {
 		printUsageAndExit(cmd, "Missing config option for 'geth.gensis'")
+	}
+
+	if opts.Bootnodes == "" && opts.StaticNodes == "" {
+		printUsageAndExit(cmd, "Either bootnodes or staticNodes are required to start geth")
 	}
 
 	return opts

--- a/service/geth/geth.go
+++ b/service/geth/geth.go
@@ -41,6 +41,7 @@ type GethOpts struct {
 	StaticNodes string
 	Bootnodes   string
 	Verbosity   string
+	PublicIp    string
 }
 
 type gethService struct {
@@ -210,6 +211,10 @@ func (gs *gethService) startGeth(stdErr *os.File) error {
 
 	if gs.opts.Bootnodes != "" {
 		gethArgs = append(gethArgs, "--bootnodes", gs.opts.Bootnodes)
+	}
+
+	if gs.opts.PublicIp != "" {
+		gethArgs = append(gethArgs, "--nat", "extip:"+gs.opts.PublicIp)
 	}
 
 	fmt.Println("geth", strings.Join(gethArgs, " "))

--- a/service/geth/geth.go
+++ b/service/geth/geth.go
@@ -174,7 +174,7 @@ func (gs *gethService) ensureGethInit() error {
 	}
 
 	gs.logger.Info("Running geth init")
-	out, err := gs.gethCmd("init", "--nousb", gs.opts.GenesisPath).CombinedOutput()
+	out, err := gs.gethCmd("init", gs.opts.GenesisPath).CombinedOutput()
 	if err != nil {
 		gs.logger.Error("Error running geth init", "err", err)
 		fmt.Println(string(out))
@@ -196,7 +196,6 @@ func (gs *gethService) startGeth(stdErr *os.File) error {
 		"--rpc",
 		"--rpcaddr", "127.0.0.1",
 		"--rpcapi", "eth,net,web3,debug,admin,personal",
-		"--verbosity", gs.opts.Verbosity,
 		"--ipcpath", gs.IpcFilePath(),
 		"--light.serve", "0",
 		"--light.maxpeers", "0",


### PR DESCRIPTION

- Simplify command line arguments config.
- Allow every option to be specified as an environment variable
- Add bootnodes, verbosity & publicip to geth config

Fixes #54 