### PR TITLE
Add release gold balances to account/balance

### DIFF
--- a/analyzer/operations.go
+++ b/analyzer/operations.go
@@ -27,12 +27,15 @@ import (
 type SubAccountType string
 
 const (
-	AccMain                    SubAccountType = "Main"
-	AccSigner                  SubAccountType = "AccountsAuthorizedSigner"
-	AccLockedGoldNonVoting     SubAccountType = "LockedGoldNonVoting"
-	AccLockedGoldVotingActive  SubAccountType = "LockedGoldVotingActive"
-	AccLockedGoldVotingPending SubAccountType = "LockedGoldVotingPending"
-	AccLockedGoldPending       SubAccountType = "LockedGoldPending"
+	AccMain                        SubAccountType = "Main"
+	AccSigner                      SubAccountType = "AccountsAuthorizedSigner"
+	AccLockedGoldNonVoting         SubAccountType = "LockedGoldNonVoting"
+	AccLockedGoldVotingActive      SubAccountType = "LockedGoldVotingActive"
+	AccLockedGoldVotingPending     SubAccountType = "LockedGoldVotingPending"
+	AccLockedGoldPending           SubAccountType = "LockedGoldPending"
+	AccReleaseGoldVested           SubAccountType = "ReleaseGoldVested"
+	AccReleaseGoldUnvestedLocked   SubAccountType = "ReleaseGoldUnvestedLocked"
+	AccReleaseGoldUnvestedUnLocked SubAccountType = "ReleaseGoldUnvestedUnlocked"
 )
 
 type SubAccount struct {

--- a/service/rpc/servicer.go
+++ b/service/rpc/servicer.go
@@ -190,7 +190,8 @@ func (s *Servicer) AccountBalance(ctx context.Context, request *types.AccountBal
 		return createResponse(NewAmount(goldAmt, CeloGold)), nil
 	}
 
-	if subAccount.Address[:len("ReleaseGold")] == "ReleaseGold" {
+	lenRg := len("ReleaseGold")
+	if lenRg <= len(subAccount.Address) && subAccount.Address[:lenRg] == "ReleaseGold" {
 		releaseGold, err := contracts.NewReleaseGold(accountAddr, s.cc.Eth)
 		if err != nil {
 			return nil, LogErrValidation(errors.New("Account address must be a ReleaseGold instance"))

--- a/service/rpc/servicer.go
+++ b/service/rpc/servicer.go
@@ -16,10 +16,12 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/celo-org/kliento/client"
+	"github.com/celo-org/kliento/contracts"
 	"github.com/celo-org/kliento/contracts/helpers"
 	"github.com/celo-org/kliento/registry"
 	"github.com/celo-org/kliento/utils/chain"
@@ -186,6 +188,47 @@ func (s *Servicer) AccountBalance(ctx context.Context, request *types.AccountBal
 			return nil, LogErrCeloClient("BalanceAt", err)
 		}
 		return createResponse(NewAmount(goldAmt, CeloGold)), nil
+	}
+
+	if subAccount.Address[:len("ReleaseGold")] == "ReleaseGold" {
+		releaseGold, err := contracts.NewReleaseGold(accountAddr, s.cc.Eth)
+		if err != nil {
+			return nil, LogErrValidation(errors.New("Account address must be a ReleaseGold instance"))
+		}
+
+		beneficiary, err := releaseGold.Beneficiary(requestedBlockOpts)
+		if err != nil {
+			return nil, LogErrCeloClient("ReleaseGold.beneficiary", err)
+		}
+
+		if subAccount.Metadata != nil {
+			if addrStr, ok := subAccount.Metadata["beneficiary"]; ok {
+				providedBeneficiary := common.HexToAddress(addrStr.(string))
+				if beneficiary != providedBeneficiary {
+					return nil, LogErrValidation(errors.New("Provided beneficiary address does not match ReleaseGold contract"))
+				}
+			}
+		}
+
+		var celoGoldAmount *big.Int
+		switch subAccount.Address {
+		case string(analyzer.AccReleaseGoldVested):
+			celoGoldAmount, err = releaseGold.GetCurrentReleasedTotalAmount(requestedBlockOpts)
+		case string(analyzer.AccReleaseGoldUnvestedUnLocked):
+			celoGoldAmount, err = releaseGold.GetRemainingUnlockedBalance(requestedBlockOpts)
+		case string(analyzer.AccReleaseGoldUnvestedLocked):
+			celoGoldAmount, err = releaseGold.GetRemainingLockedBalance(requestedBlockOpts)
+		default:
+			return nil, LogErrValidation(errors.New(fmt.Sprintf("Subaccount must be %s, %s, or %s",
+				string(analyzer.AccReleaseGoldVested),
+				string(analyzer.AccReleaseGoldUnvestedLocked),
+				string(analyzer.AccReleaseGoldUnvestedUnLocked),
+			)))
+		}
+		if err != nil {
+			return nil, LogErrCeloClient(subAccount.Address, err)
+		}
+		return createResponse(NewAmount(celoGoldAmount, CeloGold)), nil
 	}
 
 	registry, err := registry.New(s.cc)


### PR DESCRIPTION
Adds `ReleaseGoldReleaseGoldVested`, `ReleaseGoldUnvestedLocked`, `ReleaseGoldUnvestedUnlocked` sub-account types for the `account/balance` endpoint. Optionally validates against a `beneficiary` address provided in metadata (for convenience since lookup from `beneficiary => contract` is hard).

Tested on `alfajoresstaging` with coinbase dummy RG contracts

![Screen Shot 2020-07-12 at 6 31 53 PM](https://user-images.githubusercontent.com/3020995/87262248-09ea0600-c46e-11ea-9267-00b7150b36ce.png)
