### PR TITLE
Adds geth syncmode and gcmode

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -88,6 +88,9 @@ func init() {
 	flagSet.String("geth.rpcport", "8545", "Geth HTTP-RPC server listening port")
 	flagSet.String("geth.rpcvhosts", "localhost", "Geth comma separated list of virtual hostnames from which to accept requests")
 
+	flagSet.String("geth.syncmode", "fast", "Geth blockchain sync mode (fast, full, light)")
+	flagSet.String("geth.gcmode", "full", "Geth garbage collection mode (full, archive)")
+
 }
 
 func getDatadir(cmd *cobra.Command) string {
@@ -122,6 +125,8 @@ func readGethOption(cmd *cobra.Command, datadir string) *geth.GethOpts {
 		RpcAddr:     viper.GetString("geth.rpcaddr"),
 		RpcPort:     viper.GetString("geth.rpcport"),
 		RpcVHosts:   viper.GetString("geth.rpcvhosts"),
+		SyncMode:    viper.GetString("geth.syncmode"),
+		GcMode:      viper.GetString("geth.gcmode"),
 	}
 
 	if opts.GethBinary == "" {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,6 +86,7 @@ func init() {
 
 	flagSet.String("geth.rpcaddr", "127.0.0.1", "Geth HTTP-RPC server listening interface")
 	flagSet.String("geth.rpcport", "8545", "Geth HTTP-RPC server listening port")
+	flagSet.String("geth.rpcvhosts", "localhost", "Geth comma separated list of virtual hostnames from which to accept requests")
 
 }
 
@@ -120,6 +121,7 @@ func readGethOption(cmd *cobra.Command, datadir string) *geth.GethOpts {
 		PublicIp:    viper.GetString("geth.publicip"),
 		RpcAddr:     viper.GetString("geth.rpcaddr"),
 		RpcPort:     viper.GetString("geth.rpcport"),
+		RpcVHosts:   viper.GetString("geth.rpcvhosts"),
 	}
 
 	if opts.GethBinary == "" {

--- a/service/geth/geth.go
+++ b/service/geth/geth.go
@@ -44,6 +44,7 @@ type GethOpts struct {
 	PublicIp    string
 	RpcAddr     string
 	RpcPort     string
+	RpcVHosts   string
 }
 
 type gethService struct {
@@ -198,6 +199,7 @@ func (gs *gethService) startGeth(stdErr *os.File) error {
 		"--rpc",
 		"--rpcaddr", gs.opts.RpcAddr,
 		"--rpcport", gs.opts.RpcPort,
+		"--rpcvhosts", gs.opts.RpcVHosts,
 		"--rpcapi", "eth,net,web3,debug,admin,personal",
 		"--ipcpath", gs.IpcFilePath(),
 		"--light.serve", "0",

--- a/service/geth/geth.go
+++ b/service/geth/geth.go
@@ -45,6 +45,8 @@ type GethOpts struct {
 	RpcAddr     string
 	RpcPort     string
 	RpcVHosts   string
+	SyncMode    string
+	GcMode      string
 }
 
 type gethService struct {
@@ -200,6 +202,8 @@ func (gs *gethService) startGeth(stdErr *os.File) error {
 		"--rpcaddr", gs.opts.RpcAddr,
 		"--rpcport", gs.opts.RpcPort,
 		"--rpcvhosts", gs.opts.RpcVHosts,
+		"--syncmode", gs.opts.SyncMode,
+		"--gcmode", gs.opts.GcMode,
 		"--rpcapi", "eth,net,web3,debug,admin,personal",
 		"--ipcpath", gs.IpcFilePath(),
 		"--light.serve", "0",


### PR DESCRIPTION
This PR builds on top of #104 so you could choose to just merge it instead of #104 

Adds support for setting the Geth syncmode (`fast`, `full`, or `light`) as well as gcmode (`full` or `archive`)