### PR TITLE
Expose Call endpoint, fix nil struct

### DIFF
--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -138,7 +138,8 @@ func createRouter(celoClient *client.CeloClient, db db.RosettaDBReader, chainPar
 	ConstructionApiController := server.NewConstructionAPIController(servicer, asserter)
 	MempoolApiController := server.NewMempoolAPIController(servicer, asserter)
 	NetworkApiController := server.NewNetworkAPIController(servicer, asserter)
+	CallApiController := server.NewCallAPIController(servicer, asserter)
 
-	router := server.NewRouter(AccountApiController, BlockApiController, ConstructionApiController, MempoolApiController, NetworkApiController)
+	router := server.NewRouter(AccountApiController, BlockApiController, ConstructionApiController, MempoolApiController, NetworkApiController, CallApiController)
 	return router, nil
 }

--- a/service/rpc/servicer.go
+++ b/service/rpc/servicer.go
@@ -434,12 +434,12 @@ func (s *Servicer) Call(ctx context.Context, request *types.CallRequest) (*types
 
 	switch request.Method {
 	case CeloCall.String():
-		var callParams *airgap.CallParams
-		if err := airgap.UnmarshallFromMap(request.Parameters, callParams); err != nil {
+		var callParams airgap.CallParams
+		if err := airgap.UnmarshallFromMap(request.Parameters, &callParams); err != nil {
 			return nil, LogErrValidation(err)
 		}
 
-		data, err := s.airgap.CallData(ctx, callParams)
+		data, err := s.airgap.CallData(ctx, &callParams)
 		if err != nil {
 			return nil, LogErrCeloClient(request.Method, err)
 		}


### PR DESCRIPTION
This contains a few changes:
1. Create a Call API Controller and pass it into the rosetta router
2. Fix a nil struct error

