### PR TITLE
Fix CI unit tests and improve linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,10 @@ jobs:
     executor: golang
     steps:
       - *attach
-      - run: make ci-test
+      - run: |
+          mkdir -p /tmp/test-results
+          trap "go-junit-report < /tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT
+          go test -v ./... | tee /tmp/test-results/go-test.out
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output
@@ -59,7 +62,7 @@ jobs:
     executor: golang
     steps:
       - *attach
-      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.1
+      - run: make install-lint
       - run: |
           mkdir -p /tmp/test-results
           golangci-lint run --config .golangci.yml --out-format junit-xml ./... | tee /tmp/test-results/go-lint-report.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
     executor: golang
     steps:
       - *attach
-      - run: make install-lint
+      - run: make install-lint-ci
       - run: |
           mkdir -p /tmp/test-results
           golangci-lint run --config .golangci.yml --out-format junit-xml ./... | tee /tmp/test-results/go-lint-report.xml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ run:
 linters:
   disable-all: true
   enable:
-    # - deadcode
+    - deadcode
     - errcheck
     - govet
     - ineffassign

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-cover:
 fmt: 
 	go fmt ./...
 
-install-lint:
+install-lint-ci:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$(GOLANGCI_VERSION)
 
 lint: ## Run linters.

--- a/analyzer/operations.go
+++ b/analyzer/operations.go
@@ -410,6 +410,7 @@ func ReconcileLogOpsWithTransfers(logOps, transferOps []Operation, tobinTax *Tob
 	for index := range logOps {
 		logOp := logOps[index]
 		if logOp.Type.requiresTransfer() {
+			//nolint:gosec
 			matchIndex, err := findMatchAndReconcile(transferOps, &logOp, i)
 			if err != nil {
 				return nil, err

--- a/analyzer/operations.go
+++ b/analyzer/operations.go
@@ -410,7 +410,6 @@ func ReconcileLogOpsWithTransfers(logOps, transferOps []Operation, tobinTax *Tob
 	for index := range logOps {
 		logOp := logOps[index]
 		if logOp.Type.requiresTransfer() {
-			//nolint:gosec
 			matchIndex, err := findMatchAndReconcile(transferOps, &logOp, i)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Closes #112 

This fixes the issue of unit tests failing silently on CircleCI and on not being warned about mismatching `golangci-lint` versions being used on CI vs. locally. Test summaries for the unit tests now also show up properly on CircleCI.

# Problem
- Unit tests were failing because there was an issue with the `make ci-test` command. The command itself was completing successfully, even if tests within it failed. I think this is because the command `trap ... EXIT` doesn't work properly within a Makefile command. Moving the command directly into the `circleci` config fixes this problem.
- Linting looked like it was failing silently on CI. This was because the version running on CI is likely different than a locally installed version. While a more robust way of fixing this would be going towards the `celo-blockchain` solution, for now the current fix at least checks that the local linter being run is consistent with the CI linting run.

# Testing
- Checked to make sure that a failure within the unit tests now propagates through to CI failure
- Checked that the proper linter (specified in the var `GOLANGCI_VERSION`) runs on CI, and that the local CI version matches this when running `make lint`