### PR TITLE
Fix BlockNumber JSON Unmarshall

### DIFF
--- a/airgap/txargs_marshall.go
+++ b/airgap/txargs_marshall.go
@@ -30,7 +30,7 @@ type txArgsRawData struct {
 
 type callParamsRawData struct {
 	txArgsRawData
-	BlockNumber *string `json:"value,omitempty"`
+	BlockNumber *string `json:"block_number,omitempty"`
 }
 
 func (data *txArgsRawData) transform(args *TxArgs) error {


### PR DESCRIPTION
Quick fix: the JSON value for the BlockNumber was incorrect

cc: @yorhodes @pranaymohan 