### PR TITLE
Updates to Celo 1.1.1 and GoLang 1.15.5 to fix Geth CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # Stage 1: Build Rosetta
 # Outputs: binary @ /rosetta/rosetta 
 #---------------------------------------------------------------------
-FROM golang:1.15.5-alpine as builder
+FROM golang:1.14.12-alpine as builder
 WORKDIR /rosetta
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # Stage 1: Build Rosetta
 # Outputs: binary @ /rosetta/rosetta 
 #---------------------------------------------------------------------
-FROM golang:1.13-alpine as builder
+FROM golang:1.15.5-alpine as builder
 WORKDIR /rosetta
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
@@ -44,7 +44,8 @@ RUN go build --tags musl -o rosetta .
 #---------------------------------------------------------------------
 
 # adbdc7f8c27e50e77b407cb328193bd3ee823643 is mainet(1.0.0) + a few compatible commits that include tracing fix
-FROM us.gcr.io/celo-testnet/geth:adbdc7f8c27e50e77b407cb328193bd3ee823643
+# 63ece0c2482b596eac8ad9bc9d3af64e1af99a5a is mainnet(1.1.1) - unknown whether it has the tracing fixes
+FROM http://us.gcr.io/celo-org/geth:63ece0c2482b596eac8ad9bc9d3af64e1af99a5a
 ARG COMMIT_SHA
 
 RUN apk add --no-cache ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN go build --tags musl -o rosetta .
 
 # adbdc7f8c27e50e77b407cb328193bd3ee823643 is mainet(1.0.0) + a few compatible commits that include tracing fix
 # 63ece0c2482b596eac8ad9bc9d3af64e1af99a5a is mainnet(1.1.1) - unknown whether it has the tracing fixes
-FROM http://us.gcr.io/celo-org/geth:63ece0c2482b596eac8ad9bc9d3af64e1af99a5a
+FROM us.gcr.io/celo-org/geth:63ece0c2482b596eac8ad9bc9d3af64e1af99a5a
 ARG COMMIT_SHA
 
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
Note: Please confirm that the tracing fix mentioned is in 1.1.1