### PR TITLE
Implement celo_getLogs path for /call endpoint

### DIFF
--- a/airgap/api.go
+++ b/airgap/api.go
@@ -102,10 +102,10 @@ type CallParams struct {
 }
 
 type FilterQueryParams struct {
-	Contracts []string        `json:"contracts"`
-	Topics    [][]common.Hash `json:"topics"`
-	FromBlock *big.Int        `json:"from_block"`
-	ToBlock   *big.Int        `json:"to_block"`
+	Event     *CeloEvent
+	Topics    [][]interface{}
+	FromBlock *big.Int
+	ToBlock   *big.Int
 }
 
 type TxMetadata struct {

--- a/airgap/api.go
+++ b/airgap/api.go
@@ -31,6 +31,7 @@ type Server interface {
 	ObtainMetadata(ctx context.Context, txOpts *TxArgs) (*TxMetadata, error)
 	SubmitTx(ctx context.Context, rawTx []byte) (*common.Hash, error)
 	CallData(ctx context.Context, callOpts *CallParams) ([]byte, error)
+	FilterQuery(ctx context.Context, filterQueryOps *FilterQueryParams) ([]types.Log, error)
 }
 
 type ArgBuilder interface {
@@ -98,6 +99,13 @@ type TxArgs struct {
 type CallParams struct {
 	TxArgs
 	BlockNumber *big.Int
+}
+
+type FilterQueryParams struct {
+	Contracts []string        `json:"contracts"`
+	Topics    [][]common.Hash `json:"topics"`
+	FromBlock *big.Int        `json:"from_block"`
+	ToBlock   *big.Int        `json:"to_block"`
 }
 
 type TxMetadata struct {

--- a/airgap/event_registry.go
+++ b/airgap/event_registry.go
@@ -22,7 +22,7 @@ import (
 var eventRegistry = make(map[string]map[string]*CeloEvent)
 
 // FromString returns the CeloEvent that matches the given string
-// Methods are represented as "Contract.Name"
+// Events are represented as "Contract.EventName"
 func EventFromString(celoEventStr string) (*CeloEvent, error) {
 	parts := strings.Split(celoEventStr, ".")
 	if len(parts) != 2 {

--- a/airgap/event_registry.go
+++ b/airgap/event_registry.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package airgap
+
+import (
+	"fmt"
+	"strings"
+)
+
+var eventRegistry = make(map[string]map[string]*CeloEvent)
+
+// FromString returns the CeloEvent that matches the given string
+// Methods are represented as "Contract.Name"
+func EventFromString(celoEventStr string) (*CeloEvent, error) {
+	parts := strings.Split(celoEventStr, ".")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid event string: %s", celoEventStr)
+	}
+	m, ok := eventRegistry[parts[0]]
+	if !ok {
+		return nil, fmt.Errorf("Invalid event string: %s", celoEventStr)
+	}
+	cm, ok := m[parts[1]]
+	if !ok {
+		return nil, fmt.Errorf("Invalid event string: %s", celoEventStr)
+	}
+	return cm, nil
+}
+
+func registerEvent(contract string, name string, topicParsers []topicParser) *CeloEvent {
+	ce := &CeloEvent{
+		Name:         name,
+		Contract:     contract,
+		topicParsers: topicParsers,
+	}
+	// register the event in the eventRegistry
+	if eventRegistry[contract] == nil {
+		eventRegistry[contract] = make(map[string]*CeloEvent)
+	}
+	eventRegistry[contract][name] = ce
+	return ce
+}

--- a/airgap/events.go
+++ b/airgap/events.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package airgap
+
+import (
+	"fmt"
+
+	"github.com/celo-org/kliento/registry"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	// Election
+	EpochRewardsDistributedToVoters = registerEvent(registry.ElectionContractID.String(), "EpochRewardsDistributedToVoters", []topicParser{addressTopicParser})
+)
+
+type CeloEvent struct {
+	// Name of the abi method
+	Name string
+	// Registry id of contract where the method is defined
+	Contract string
+
+	topicParsers []topicParser
+}
+
+func (cm *CeloEvent) String() string { return fmt.Sprintf("%s.%s", cm.Contract, cm.Name) }
+
+func (ce *CeloEvent) DeserializeTopics(values ...[]interface{}) ([][]common.Hash, error) {
+	if len(values) > len(ce.topicParsers) {
+		return nil, fmt.Errorf("Received %d topics; expected at most %d", len(values), len(ce.topicParsers))
+	}
+	parsedTopics := make([][]common.Hash, len(values))
+
+	var err error
+	for i, topicGroup := range values {
+		parsedTopicGroup := make([]common.Hash, len(topicGroup))
+		for j, topic := range topicGroup {
+			parsedTopicGroup[j], err = ce.topicParsers[i](topic)
+			if err != nil {
+				return nil, fmt.Errorf("bad argument: idx=%d,%d error=%w", i, j, err)
+			}
+		}
+		parsedTopics[i] = parsedTopicGroup
+	}
+
+	return parsedTopics, nil
+}

--- a/airgap/filterquery_marshall.go
+++ b/airgap/filterquery_marshall.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package airgap
+
+import (
+	"encoding/json"
+)
+
+type filterQueryRawData struct {
+	Event     *string         `json:"event,omitempty"`
+	FromBlock *string         `json:"from_block,omitempty"`
+	ToBlock   *string         `json:"to_block,omitempty"`
+	Topics    [][]interface{} `json:"topics,omitempty"`
+}
+
+func (data *filterQueryRawData) transform(args *FilterQueryParams) error {
+	var err error
+	args.FromBlock, err = stringToBigInt(data.FromBlock)
+	if err != nil {
+		return err
+	}
+	args.ToBlock, err = stringToBigInt(data.ToBlock)
+	if err != nil {
+		return err
+	}
+	args.Event, err = stringToEvent(data.Event)
+	if err != nil {
+		return err
+	}
+
+	args.Topics = data.Topics
+	return nil
+}
+
+func (args *FilterQueryParams) transform() *filterQueryRawData {
+	var data filterQueryRawData
+	data.FromBlock = bigIntToString(args.FromBlock)
+	data.ToBlock = bigIntToString(args.ToBlock)
+	if args.Event != nil {
+		var str = args.Event.String()
+		data.Event = &str
+	}
+	data.Topics = args.Topics
+	return &data
+}
+
+func (args FilterQueryParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(args.transform())
+}
+
+func (args *FilterQueryParams) UnmarshalJSON(b []byte) error {
+	var err error
+
+	var data filterQueryRawData
+	if err = json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	return data.transform(args)
+}

--- a/airgap/filterquery_marshall_test.go
+++ b/airgap/filterquery_marshall_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package airgap
+
+import (
+	"math/big"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFilterQueryMarshalling(t *testing.T) {
+	RegisterTestingT(t)
+
+	samples := []struct {
+		name   string
+		sample FilterQueryParams
+	}{
+		{
+			name: "Complete",
+			sample: FilterQueryParams{
+				Event:     EpochRewardsDistributedToVoters,
+				Topics:    [][]interface{}{[]interface{}{"0x00000011"}}, // these will be simple types always
+				FromBlock: big.NewInt(1000),
+				ToBlock:   big.NewInt(2000),
+			},
+		},
+		{
+			name: "Nil Values",
+			sample: FilterQueryParams{
+				Event: EpochRewardsDistributedToVoters,
+			},
+		},
+	}
+
+	for _, sample := range samples {
+		input := sample.sample
+
+		t.Run(sample.name, func(t *testing.T) {
+			t.Run("Json", func(t *testing.T) {
+				RegisterTestingT(t)
+
+				var output FilterQueryParams
+				err := simulateWire(input, &output)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(output).Should(Equal(input))
+			})
+
+			t.Run("JsonWithPointer", func(t *testing.T) {
+				RegisterTestingT(t)
+
+				var output FilterQueryParams
+				err := simulateWire(&input, &output)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(output).Should(Equal(input))
+			})
+
+			t.Run("Map", func(t *testing.T) {
+				RegisterTestingT(t)
+
+				var output FilterQueryParams
+
+				theMap, err := MarshallToMap(input)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				err = UnmarshallFromMap(theMap, &output)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(output).Should(Equal(input))
+			})
+
+			t.Run("MapThenJson", func(t *testing.T) {
+				RegisterTestingT(t)
+
+				theMap, err := MarshallToMap(input)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				var overTheWireMap map[string]interface{}
+				err = simulateWire(theMap, &overTheWireMap)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				var output FilterQueryParams
+				err = UnmarshallFromMap(overTheWireMap, &output)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(output).Should(Equal(input))
+
+			})
+
+		})
+	}
+}

--- a/airgap/marshall_helpers.go
+++ b/airgap/marshall_helpers.go
@@ -74,3 +74,14 @@ func stringToMethod(input *string) (*CeloMethod, error) {
 	}
 	return out, nil
 }
+
+func stringToEvent(input *string) (*CeloEvent, error) {
+	if input == nil {
+		return nil, nil
+	}
+	out, err := EventFromString(*input)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/airgap/server/events.go
+++ b/airgap/server/events.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/celo-org/rosetta/airgap"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var serverCallEventDefinitions = []*airgap.CeloEvent{
+	airgap.EpochRewardsDistributedToVoters,
+}
+
+func hydrateEvents(srvCtx ServerContext, events []*airgap.CeloEvent) (map[*airgap.CeloEvent]airGapServerEvent, error) {
+	abis := make(map[string]*abi.ABI)
+	for id, abiFactory := range abiFactoryMap {
+		abi, err := abiFactory()
+		if err != nil {
+			return nil, err
+		}
+		abis[id] = abi
+	}
+
+	mappedEvents := make(map[*airgap.CeloEvent]airGapServerEvent)
+	for _, event := range events {
+		abi, ok := abis[event.Contract]
+		if !ok {
+			return nil, fmt.Errorf("Missing abi mapping for %s", event.Contract)
+		}
+		evt, ok := abi.Events[event.Name]
+		if !ok {
+			return nil, fmt.Errorf("Missing event data for %s", event.Name)
+		}
+
+		mappedEvents[event] = airgapEventFactory(srvCtx, evt, event)
+	}
+	return mappedEvents, nil
+}
+
+func airgapEventFactory(srvCtx ServerContext, evt abi.Event, event *airgap.CeloEvent) airGapServerEvent {
+	return func(ctx context.Context, restTopics [][]common.Hash) [][]common.Hash {
+		topic0 := evt.ID()
+		var topics [][]common.Hash
+		topics = append(topics, []common.Hash{topic0})
+		topics = append(topics, restTopics...)
+
+		return topics
+	}
+}

--- a/airgap/server/server.go
+++ b/airgap/server/server.go
@@ -30,7 +30,7 @@ import (
 // airGapServerMethod is a function that returns the tx.data for that method + parameters
 type airGapServerMethod func(context.Context, []interface{}) ([]byte, error)
 
-// airGapServerMethod is a function that returns the topic[0] for that event name + parameters
+// airGapServerEvent is a function that returns the topic[0] for that event name + parameters
 type airGapServerEvent func(context.Context, [][]common.Hash) [][]common.Hash
 
 type airGapServerImpl struct {

--- a/airgap/server/server.go
+++ b/airgap/server/server.go
@@ -30,11 +30,15 @@ import (
 // airGapServerMethod is a function that returns the tx.data for that method + parameters
 type airGapServerMethod func(context.Context, []interface{}) ([]byte, error)
 
+// airGapServerMethod is a function that returns the topic[0] for that event name + parameters
+type airGapServerEvent func(context.Context, [][]common.Hash) [][]common.Hash
+
 type airGapServerImpl struct {
 	srvCtx             ServerContext
 	chainId            *big.Int
 	transactionMethods map[*airgap.CeloMethod]airGapServerMethod
 	callMethods        map[*airgap.CeloMethod]airGapServerMethod
+	callEvents         map[*airgap.CeloEvent]airGapServerEvent
 }
 
 func NewAirgapServer(chainId *big.Int, srvCtx ServerContext) (airgap.Server, error) {
@@ -48,11 +52,17 @@ func NewAirgapServer(chainId *big.Int, srvCtx ServerContext) (airgap.Server, err
 		return nil, err
 	}
 
+	callEvents, err := hydrateEvents(srvCtx, serverCallEventDefinitions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &airGapServerImpl{
 		srvCtx,
 		chainId,
 		transactionMethods,
 		callMethods,
+		callEvents,
 	}, nil
 }
 
@@ -164,20 +174,32 @@ func (b *airGapServerImpl) ObtainMetadata(ctx context.Context, options *airgap.T
 }
 
 func (b *airGapServerImpl) FilterQuery(ctx context.Context, options *airgap.FilterQueryParams) ([]types.Log, error) {
-	var addresses []common.Address
-	for _, contract := range options.Contracts {
-		address, err := b.srvCtx.addressFor(ctx, registry.ContractID(contract), options.FromBlock)
-		if err != nil {
-			return nil, fmt.Errorf("'Contract' not a valid registry ID")
-		}
-		addresses = append(addresses, address)
+	if options.Event == nil {
+		return nil, fmt.Errorf("'Event' must be provided as options")
+	}
+
+	serverEvent, ok := b.callEvents[options.Event]
+	if !ok {
+		return nil, fmt.Errorf("Unsupported event: %v", options.Event)
+	}
+
+	hydratedTopics, err := options.Event.DeserializeTopics(options.Topics...)
+	if err != nil {
+		return nil, err
+	}
+
+	topics := serverEvent(ctx, hydratedTopics)
+
+	address, err := b.srvCtx.addressFor(ctx, registry.ContractID(options.Event.Contract), options.FromBlock)
+	if err != nil {
+		return nil, fmt.Errorf("'%s' not a valid registry ID", options.Event.Contract)
 	}
 
 	query := ethereum.FilterQuery{
-		Addresses: addresses,
+		Addresses: []common.Address{address},
 		FromBlock: options.FromBlock,
 		ToBlock:   options.ToBlock,
-		Topics:    options.Topics,
+		Topics:    topics,
 	}
 	return b.srvCtx.FilterLogs(ctx, query)
 }

--- a/airgap/server/server_context.go
+++ b/airgap/server/server_context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -39,6 +40,7 @@ type ServerContext interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
 	SendRawTransaction(ctx context.Context, data []byte) (*common.Hash, error)
 }

--- a/airgap/server/server_context_stub_test.go
+++ b/airgap/server/server_context_stub_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/celo-org/kliento/registry"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type serverContextStub struct{}
@@ -73,4 +74,16 @@ func (sc *serverContextStub) NonceAt(ctx context.Context, account common.Address
 func (sc *serverContextStub) SendRawTransaction(ctx context.Context, data []byte) (*common.Hash, error) {
 	hash := common.HexToHash("0x666777888")
 	return &hash, nil
+}
+
+func (sc *serverContextStub) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	log := types.Log{
+		Address:   common.HexToAddress("0x01"),
+		Topics:    []common.Hash{common.HexToHash("0x666777888")},
+		Data:      []byte{100},
+		BlockHash: common.HexToHash("0x123"),
+		TxHash:    common.HexToHash("0xfoobar"),
+		TxIndex:   0,
+	}
+	return []types.Log{log}, nil
 }

--- a/airgap/topic_parsers.go
+++ b/airgap/topic_parsers.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package airgap
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type topicParser func(interface{}) (common.Hash, error)
+
+func addressTopicParser(value interface{}) (common.Hash, error) {
+	switch v := value.(type) {
+	case string:
+		return common.HexToHash(v), nil
+	case common.Address:
+		return v.Hash(), nil
+	default:
+		return common.ZeroAddress.Hash(), fmt.Errorf("Not a valid address: %v", v)
+	}
+}
+
+func bytesTopicParser(value interface{}) (common.Hash, error) {
+	var res common.Hash
+	switch v := value.(type) {
+	case string:
+		res = common.HexToHash(v)
+	case []uint8:
+		res = common.BytesToHash(v)
+	default:
+		return common.Hash{}, fmt.Errorf("Not a valid []byte: %v", v)
+	}
+	return res, nil
+}
+
+func bigIntTopicParser(value interface{}) (common.Hash, error) {
+	var ret *big.Int
+	switch v := value.(type) {
+	case string:
+		val, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			return common.Hash{}, fmt.Errorf("Not a big.Int: %s", val)
+		}
+		return common.BigToHash(val), nil
+	case int:
+		ret = new(big.Int).SetInt64(int64(v))
+	case int64:
+		ret = new(big.Int).SetInt64(v)
+	case uint:
+		ret = new(big.Int).SetUint64(uint64(v))
+	case uint64:
+		ret = new(big.Int).SetUint64(v)
+	case float32:
+		ret = new(big.Int).SetInt64(int64(v))
+	case float64:
+		ret = new(big.Int).SetInt64(int64(v))
+	case *big.Int:
+		ret = v
+	default:
+		return common.Hash{}, fmt.Errorf("Not a big.Int: %v", v)
+	}
+	return common.BigToHash(ret), nil
+}

--- a/airgap/topic_parsers_test.go
+++ b/airgap/topic_parsers_test.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package airgap
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	. "github.com/onsi/gomega"
+)
+
+func TestTopicParsers(t *testing.T) {
+	RegisterTestingT(t)
+
+	type testCase struct {
+		input  interface{}
+		output common.Hash
+		fails  bool
+	}
+
+	parserTest := func(name string, parser topicParser, testCases []testCase) {
+		t.Run(name, func(t *testing.T) {
+			for _, _case := range testCases {
+				testCase := _case
+				t.Run(fmt.Sprintf("input %#v => (%t", testCase.input, !testCase.fails), func(t *testing.T) {
+					RegisterTestingT(t)
+					ret, err := parser(testCase.input)
+					if testCase.fails {
+						Ω(err).Should(HaveOccurred())
+					} else {
+						Ω(err).ShouldNot(HaveOccurred())
+						Ω(ret).Should(Equal(testCase.output))
+					}
+
+				})
+			}
+		})
+	}
+
+	parserTest("address", addressTopicParser, []testCase{
+		{
+			input:  "0x111",
+			output: common.HexToHash("0x111"),
+		},
+		{
+			input:  "1111111",
+			output: common.HexToHash("0x1111111"),
+		},
+		{
+			input:  common.HexToAddress("0x1111111"),
+			output: common.HexToHash("0x1111111"),
+		},
+		{
+			input: 999999,
+			fails: true,
+		},
+	})
+
+	parserTest("bigInt", bigIntTopicParser, []testCase{
+		{
+			input:  big.NewInt(1000),
+			output: common.HexToHash("0x3e8"),
+		},
+		{
+			input:  1000,
+			output: common.HexToHash("0x3e8"),
+		},
+		{
+			input:  float64(1000),
+			output: common.HexToHash("0x3e8"),
+		},
+		{
+			input:  uint64(1000),
+			output: common.HexToHash("0x3e8"),
+		},
+		{
+			input:  int64(1000),
+			output: common.HexToHash("0x3e8"),
+		},
+		{
+			input:  "1000",
+			output: common.HexToHash("0x3e8"),
+		},
+	})
+
+	parserTest("bytes", bytesTopicParser, []testCase{
+		{
+			input:  []byte{1, 2, 3},
+			output: common.BytesToHash([]byte{1, 2, 3}),
+		},
+		{
+			input:  []uint8{1, 2, 3},
+			output: common.BytesToHash([]byte{1, 2, 3}),
+		},
+		{
+			input:  "0x010203",
+			output: common.BytesToHash([]byte{1, 2, 3}),
+		},
+		{
+			input:  "010203",
+			output: common.BytesToHash([]byte{1, 2, 3}),
+		},
+	})
+}


### PR DESCRIPTION
First pass implementation of the `celo_getLogs` path for the `/call` Rosetta endpoint. This is mostly a passthrough to `ethclient.FilterLogs` with contract registry parsing on top.

Let me know if this interface makes sense or if it could be improved

cc: @yorhodes 