### PR TITLE
WIP: Allow user to pass 'to' via call API

### DIFF
--- a/airgap/server/server.go
+++ b/airgap/server/server.go
@@ -90,9 +90,14 @@ func (b *airGapServerImpl) CallData(ctx context.Context, options *airgap.CallPar
 		return nil, err
 	}
 
-	to, err := b.srvCtx.addressFor(ctx, registry.ContractID(options.Method.Contract), options.BlockNumber)
-	if err != nil {
-		return nil, fmt.Errorf("'Contract' not a valid registry ID")
+	var to common.Address
+	if options.To != nil {
+		to = *options.To
+	} else {
+		to, err = b.srvCtx.addressFor(ctx, registry.ContractID(options.Method.Contract), options.BlockNumber)
+		if err != nil {
+			return nil, fmt.Errorf("'Contract' not a valid registry ID")
+		}
 	}
 
 	return b.srvCtx.CallContract(ctx, ethereum.CallMsg{


### PR DESCRIPTION
This would allow a user to submit a request to call the specified `method` at the contract address specified under `to`. If no `to` is passed in, then look up the registry address of the specified contract.

Downsides to this are that a user could theoretically call a method registered for a particular contract on a different contract (specified as address). While I don't think this is dangerous (a user could do the same thing normally outside of Rosetta; this isn't allowing behavior that couldn't happen elsewhere), this could lead to weird situations/unclear reasons for failure.