### PR TITLE
Bump go version to match docker and middleware version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
         user: root
     working_directory: /go/src/github.com/celo-org/rosetta
 attach: &attach

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For a code resource, please see the [examples](./examples/airgap/main.go).
 ### Setup
 
 You need:
-  * go >= 1.13
+  * go >= 1.14
   * rust >= 1.41.0
   * openapi-generator To re-generate rpc scaffold ([install link](https://openapi-generator.tech))
   * golangci To run linter (check https://github.com/golangci/golangci-lint#install )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celo-org/rosetta
 
-go 1.13
+go 1.14
 
 require (
 	github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44
@@ -23,4 +23,4 @@ require (
 // replace github.com/ethereum/go-ethereum => ../celo-blockchain
 
 // Use this to use external build
-replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v0.0.0-20200612100840-bf2ba25426f9
+replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/TrueFurby/go-callvis v0.5.0/go.mod h1:pfgf1uM6TTFZd68pcT2AkejZeaOZWZS8enaj8NQ/fa8=
 github.com/VictoriaMetrics/fastcache v1.5.2 h1:Erd8iIuBAL9kke8JzM4+WxkKuFkHh3ktwLanJvDgR44=
 github.com/VictoriaMetrics/fastcache v1.5.2/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
+github.com/VictoriaMetrics/fastcache v1.5.3 h1:2odJnXLbFZcoV9KYtQ+7TH1UOq3dn3AssMgieaezkR4=
+github.com/VictoriaMetrics/fastcache v1.5.3/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -42,6 +44,7 @@ github.com/aristanetworks/goarista v0.0.0-20190912214011-b54698eaaca6 h1:6bZNnQc
 github.com/aristanetworks/goarista v0.0.0-20190912214011-b54698eaaca6/go.mod h1:Z4RTxGAuYhPzcq8+EdRM+R8M48Ssle2TsWtwRKa+vns=
 github.com/aristanetworks/splunk-hec-go v0.3.3/go.mod h1:1VHO9r17b0K7WmOlLb9nTk/2YanvOEnLMUgsFrxBROc=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -67,8 +70,12 @@ github.com/celo-org/bls-zexe/go v0.0.0-20200502082044-230d2f4866d5 h1:9tRTgwOba1
 github.com/celo-org/bls-zexe/go v0.0.0-20200502082044-230d2f4866d5/go.mod h1:CzbB0Yl65q4G1bsLEZGKW+wTLdIInCLLXyJSL7IZqnk=
 github.com/celo-org/celo-blockchain v0.0.0-20200612100840-bf2ba25426f9 h1:hBlXuAwnR62EHo1xHSoXcG6CYWwSL5YWArRhKneWzJU=
 github.com/celo-org/celo-blockchain v0.0.0-20200612100840-bf2ba25426f9/go.mod h1:Ic7V/8BExGs53cByD3Fn9b/F2qjCi6QoDDFSr5aOEQk=
+github.com/celo-org/celo-blockchain v1.1.1 h1:R6w5ckC7J/BfLIBh4qElZ7E55vRZFEdKfkLwTC16M8s=
+github.com/celo-org/celo-blockchain v1.1.1/go.mod h1:/3n/+Rf2pTN4j8qenJ2kAK/yCqKeMoMR2e+X2k42qsU=
 github.com/celo-org/celo-bls-go v0.1.4 h1:d99spabDiuyMJ4uYa/0MbpCsEhaWSYNIujIoZ5Bu38o=
 github.com/celo-org/celo-bls-go v0.1.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
+github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGHIhCB8=
+github.com/celo-org/celo-bls-go v0.1.6/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44 h1:OIwtA7H4/P/9nh6ZL4Q2vZ9VO8azMzo7X0jyKRNrs0c=
 github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44/go.mod h1:OrzUyeaXpAgTfhl0+wUG4Y+Tfn+wpL49t2/5S9z9zjQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -79,6 +86,8 @@ github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.0.1-0.20190104013014-3767db7a7e18 h1:pl4eWIqvFe/Kg3zkn7NxevNzILnZYWDCG7qbA1CJik0=
 github.com/cespare/xxhash/v2 v2.0.1-0.20190104013014-3767db7a7e18/go.mod h1:HD5P3vAIAh+Y2GAxg0PrPN1P8WkepXGpjbUPDHJqqKM=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/coinbase/rosetta-sdk-go v0.5.9 h1:CuGQE3HFmYwdEACJnuOtVI9cofqPsGvq6FdFIzaOPKI=
@@ -209,6 +218,7 @@ github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -423,6 +433,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
@@ -436,6 +447,7 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20200329125638-4c31acba0007/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
+golang.org/x/mobile v0.0.0-20200801112145-973feb4309de/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -456,6 +468,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190921015927-1a5e07d1ff72/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/rosetta-cli-conf/mainnet/bootstrap_balances.json
+++ b/rosetta-cli-conf/mainnet/bootstrap_balances.json
@@ -1,0 +1,312 @@
+[
+ {
+  "account_identifier": {
+   "address": "0xaa9064F57F8d7de4b3e08c35561E21Afd6341390"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x08960Ce6b58BE32FBc6aC1489d04364B4f7dC216"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x7cf091C954ed7E9304452d31fd59999505Ddcb7a"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "14375000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x8e1c4355307F1A59E7eD4Ae057c51368b9338C38"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "7291740000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xa5d2944C32a8D7b284fF0b84c20fDcc46937Cf64"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "14375000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x3Fa7C646599F3174380BD9a7B6efCde90b5d129d"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "14375000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xC1cDA18694F5B86cFB80c1B4f8Cc046B0d7E6326"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x7FA26b50b3e9a2eC8AD1850a4c4FBBF94D806E95"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xDe22679dCA843B424FD0BBd70A22D5F5a4B94fe4"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "10200014000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xB80d1e7F9CEbe4b5E1B1Acf037d3a44871105041"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "9581366833333333333333335"
+ },
+ {
+  "account_identifier": {
+   "address": "0x8A07541C2eF161F4e3f8de7c7894718dA26626B2"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "11218686833333333333333333"
+ },
+ {
+  "account_identifier": {
+   "address": "0xB2fe7AFe178335CEc3564d7671EEbD7634C626B0"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "11218686833333333333333333"
+ },
+ {
+  "account_identifier": {
+   "address": "0x8d485780E84E23437f8F6938D96B964645529127"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x75Bb69C002C43f5a26a2A620518775795Fd45ecf"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x19992AE48914a178Bf138665CffDD8CD79b99513"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x743D80810fe10c5C3346D2940997cC9647035B13"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20513322000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x1B6C64779F42BA6B54C853Ab70171aCd81b072F7"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20025000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x11901cf7eEae1E2644995FB2E47Ce46bC7F33246"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "120000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xF5720c180a6Fa14ECcE82FB1bB060A39E93A263c"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "30000061000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xf8ed78A113cD2a34dF451Ba3D540FFAE66829AA0"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "11218686833333333333333333"
+ },
+ {
+  "account_identifier": {
+   "address": "0xFC89C17525f08F2Bc9bA8cb77BcF05055B1F7059"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "14375000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xAe1d640648009DbE0Aa4485d3BfBB68C37710924"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20025000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x417fe63186C388812e342c85FF87187Dc584C630"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000062000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xeF283eca68DE87E051D427b4be152A7403110647"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "14375000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x77B68B2e7091D4F242a8Af89F200Af941433C6d8"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x9033ff75af27222c8f36a148800c7331581933F3"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "11218686833333333333333333"
+ },
+ {
+  "account_identifier": {
+   "address": "0xa5d40D93b01AfBafec84E20018Aff427628F645E"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0x5F857c501b73ddFA804234f1f1418D6f75554076"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xE23a4c6615669526Ab58E9c37088bee4eD2b2dEE"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "20000000000000000000000"
+ },
+ {
+  "account_identifier": {
+   "address": "0xc471776eA02705004C451959129bF09423B56526"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "11218686833333333333333333"
+ },
+ {
+  "account_identifier": {
+   "address": "0x989e1a3B344A43911e02cCC609D469fbc15AB1F1"
+  },
+  "currency": {
+   "symbol": "cGLD",
+   "decimals": 18
+  },
+  "value": "14375000000000000000000000"
+ }
+]

--- a/rosetta-cli-conf/mainnet/cli-config.json
+++ b/rosetta-cli-conf/mainnet/cli-config.json
@@ -1,0 +1,47 @@
+{
+    "network": {
+      "blockchain": "celo",
+      "network": "42220"
+    },
+    "online_url": "http://localhost:8080",
+    "data_directory": "",
+    "http_timeout": 300,
+    "max_retries": 5,
+    "retry_elapsed_time": 0,
+    "max_online_connections": 120,
+    "max_sync_concurrency": 1,
+    "tip_delay": 300,
+    "log_configuration": false,
+    "compression_disabled": false,
+    "memory_limit_disabled": false,
+    "construction": null,
+    "data": {
+      "active_reconciliation_concurrency": 16,
+      "inactive_reconciliation_concurrency": 4,
+      "inactive_reconciliation_frequency": 250,
+      "log_blocks": false,
+      "log_transactions": false,
+      "log_balance_changes": false,
+      "log_reconciliations": false,
+      "ignore_reconciliation_error": false,
+      "exempt_accounts": "",
+      "bootstrap_balances": "bootstrap_balances.json",
+      "interesting_accounts": "",
+      "reconciliation_disabled": false,
+      "reconciliation_drain_disabled": false,
+      "inactive_discrepency_search_disabled": false,
+      "balance_tracking_disabled": false,
+      "coin_tracking_disabled": false,
+      "status_port": 9090,
+      "results_output_file": "",
+      "pruning_disabled": false,
+      "initial_balance_fetch_disabled": false,
+      "end_conditions": {
+        "duration": 300,
+        "reconciliation_coverage": {
+          "coverage": 0.95
+        }
+      }
+    }
+  }
+  

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.7.2"
+	MiddlewareVersion = "0.7.4"
 	NodeVersion       = params.Version
 )

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.7.4"
+	MiddlewareVersion = "0.7.5"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
- Increments package `go` version to match already incremented docker version
- bumps Middleware version to `0.7.5` for release
- added mainnet cli config for mainnet testing

# Testing
- [x] unit tests pass
- [x] ran data checks locally for `alfajores` for a fixed duration
- [x] ran data checks locally for `rc1` for a fixed duration
- [x] manual testing of data API endpoints