### PR TITLE
Update instructions for running from source + docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Running the Rosetta RPC Server from scratch will take some time to sync, since i
 
 ### Version 1: Running from `rosetta` source code
 
-You will need the following three repositories cloned locally: `rosetta` (this repo), [`celo-monorepo`](https://github.com/celo-org/celo-monorepo), [`celo-blockchain`](https://github.com/celo-org/celo-blockchain). You also need: `go >= 1.14`, `rust >= 1.41.0` (blockchain dependency)
+You will need the following three repositories cloned locally: `rosetta` (this repo), [`celo-monorepo`](https://github.com/celo-org/celo-monorepo), [`celo-blockchain`](https://github.com/celo-org/celo-blockchain). You also need: `go >= 1.14`, `rust >= 1.41.0` (`blockchain` dependency), and `node = 10` (`celo-monorepo` dependency).
 
 #### Running on Alfajores (Testnet)
 
 Prerequisites:
 
-* Checkout `celo-monorepo` branch `alfajores` and run `yarn && yarn build`
+* Checkout `celo-monorepo` branch `alfajores` and run `yarn && yarn build --ignore docs`
 * Checkout `celo-blockchain` tag `v1.1.2` (NOTE: check that this matches the version specified in the `rosetta` `go.mod` file) and `make all`
 * Export paths to `celo-monorepo` and `celo-blockchain` as `CELO_MONOREPO_PATH` and `CELO_BLOCKCHAIN_PATH` respectively (can be paths relative to `rosetta` repo)
 * Checkout `rosetta` tag `v0.7.6` (or latest released tag) and `make gen-contracts && make all`
@@ -109,7 +109,7 @@ This is the same as above with a few differences (generally: specifying `rc1` vs
 
 Prerequisites:
 
-* Checkout `celo-monorepo` branch `rc1` instead of `alfajores`, run `yarn && yarn build` as above
+* Checkout `celo-monorepo` branch `rc1` instead of `alfajores`, run `yarn && yarn build --ignore docs` as above
 * `celo-blockchain`: same as above
 * Export paths: same as above
 * Checkout `rosetta`: same as above
@@ -129,9 +129,7 @@ go run main.go run \
 
 ### Version 2: Running Rosetta Docker Image
 
-***Note:** This is currently slightly out of date, but we are working on getting this up-to-date and improving our release process.*
-
-Rosetta is released as a docker image: `us.gcr.io/celo-testnet/rosetta`. All version can be found on the [registry page](https://us.gcr.io/celo-testnet/rosetta). Within the docker image, we pack `rosetta` binary and also `geth` binary from celo-blockchain. Rosetta will run both.
+Rosetta is released as a docker image: `us.gcr.io/celo-testnet/rosetta`. All versions can be found on the [registry page](https://us.gcr.io/celo-testnet/rosetta). Within the docker image, we pack the `rosetta` binary and also the `geth` binary from `celo-blockchain`. Rosetta will run both.
 
 The command below runs the Celo Rosetta RPC server for `alfajores`:
 
@@ -158,8 +156,6 @@ To run this for a different network, replace the genesis block generation and st
 * `genesis.json` for the target network (can be found by running the following, selecting one of `alfajores`, `baklava`, `rc1` as `<NETWORK>` in `curl 'https://storage.googleapis.com/genesis_blocks/<NETWORK>' > genesis.json`).
 * `staticNodes` or `bootnodes`.
   * With `staticNodes` Rosetta will directly peer to the list of staticNode provided. This node can be any you have access to. For a public list check `https://storage.cloud.google.com/static_nodes/<NETWORK>`
-
-
 
 ## Airgap Client Guide
 
@@ -196,16 +192,14 @@ You need:
 
 * go >= 1.14
 * rust >= 1.41.0
+* node = 10
 * openapi-generator To re-generate rpc scaffold ([install link](https://openapi-generator.tech))
 * golangci To run linter (check https://github.com/golangci/golangci-lint#install )
 
-`Makefile` requires the following env variables:
+`Makefile` requires the following env variable to be set and pointed to your local `celo-blockchain` and `celo-monorepo` clones, respectively:
 
 * `CELO_BLOCKCHAIN_PATH`
 * `CELO_MONOREPO_PATH`
-
-`go.mod` is set up to build `celo-blockchain` from `../celo-blockchain`. Which is the default path,
-if you need to change it **DON'T COMMIT IT**
 
 ### Build Commands
 
@@ -224,13 +218,6 @@ Rosetta requires a few Celo Core Contracts
 * Generation requires acces to `celo-blockchain` & `celo-monorepo`.
 * Generation assumes both projects are **already properly built**
 * To run generator do `make gen-contracts`
-
-## How to build Docker Image
-
-Commands:
-
-* `make docker-build`
-* `make docker-publish`
 
 ## How to run rosetta-cli-checks
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Running the Rosetta RPC Server from scratch will take some time to sync, since i
 
 ### Version 1: Running from `rosetta` source code
 
-You will need the following three repositories cloned locally: `rosetta` (this repo), [`celo-monorepo`](https://github.com/celo-org/celo-monorepo), [`celo-blockchain`](https://github.com/celo-org/celo-blockchain). You also need: `go >= 1.14`, `rust >= 1.41.0` (`blockchain` dependency), and `node = 10` (`celo-monorepo` dependency).
+You will need the following three repositories cloned locally: `rosetta` (this repo), [`celo-monorepo`](https://github.com/celo-org/celo-monorepo), [`celo-blockchain`](https://github.com/celo-org/celo-blockchain). You also need: `go >= 1.14`, `rust >= 1.41.0` (`blockchain` dependency), `node = 10` (`celo-monorepo` dependency), and `golangci` ([installation instructions](https://golangci-lint.run/usage/install/#local-installation)) (linter dependency for the Makefile).
 
 #### Running on Alfajores (Testnet)
 
@@ -193,8 +193,8 @@ You need:
 * go >= 1.14
 * rust >= 1.41.0
 * node = 10
+* golangci ([install link](https://golangci-lint.run/usage/install/#local-installation))
 * openapi-generator To re-generate rpc scaffold ([install link](https://openapi-generator.tech))
-* golangci To run linter (check https://github.com/golangci/golangci-lint#install )
 
 `Makefile` requires the following env variable to be set and pointed to your local `celo-blockchain` and `celo-monorepo` clones, respectively:
 

--- a/README.md
+++ b/README.md
@@ -77,16 +77,33 @@ Running the Rosetta RPC Server from scratch will take some time to sync, since i
 
 ### Version 1: Running from `rosetta` source code
 
-You will need the following three repositories cloned locally: `rosetta` (this repo), [`celo-monorepo`](https://github.com/celo-org/celo-monorepo), [`celo-blockchain`](https://github.com/celo-org/celo-blockchain). You also need: `go >= 1.14`, `rust >= 1.41.0` (`blockchain` dependency), `node = 10` (`celo-monorepo` dependency), and `golangci` ([installation instructions](https://golangci-lint.run/usage/install/#local-installation)) (linter dependency for the Makefile).
+You will need the following three repositories cloned locally:
+
+* `rosetta` (this repo)
+* [`celo-monorepo`](https://github.com/celo-org/celo-monorepo)
+* [`celo-blockchain`](https://github.com/celo-org/celo-blockchain)
+
+You also need the following dependencies to be met:
+
+* `go >= 1.14`
+* `rust >= 1.41.0` (`blockchain` dependency)
+* `node = 10` (`celo-monorepo` dependency)
+* `golangci` ([installation instructions](https://golangci-lint.run/usage/install/#local-installation)) (linter dependency for the Makefile)
 
 #### Running on Alfajores (Testnet)
 
 Prerequisites:
 
 * Checkout `celo-monorepo` branch `alfajores` and run `yarn && yarn build --ignore docs`
-* Checkout `celo-blockchain` tag `v1.1.2` (NOTE: check that this matches the version specified in the `rosetta` `go.mod` file) and `make all`
-* Export paths to `celo-monorepo` and `celo-blockchain` as `CELO_MONOREPO_PATH` and `CELO_BLOCKCHAIN_PATH` respectively (can be paths relative to `rosetta` repo)
-* Checkout `rosetta` tag `v0.7.6` (or latest released tag) and `make gen-contracts && make all`
+* Checkout `celo-blockchain` tag `v1.1.2` (`git fetch --all && git checkout v1.1.2`) (NOTE: check that this matches the version specified in the `rosetta` `go.mod` file) and `make all`
+* Set paths to `celo-monorepo` and `celo-blockchain` as `CELO_MONOREPO_PATH` and `CELO_BLOCKCHAIN_PATH` respectively (paths can be absolute or relative to the `rosetta` repo. If desired, add these lines to your bash profile:
+
+  ```sh
+  export CELO_MONOREPO_PATH=path/to/celo-monorepo
+  export CELO_BLOCKCHAIN_PATH=path/to/celo-blockchain
+  ```
+
+* Checkout `rosetta` tag `v0.7.6` (`git fetch --all && git checkout v0.7.6`) (or latest released tag) and `make gen-contracts && make all`
 * Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service)
 
 Then run:
@@ -188,15 +205,11 @@ For a code resource, please see the [examples](./examples/airgap/main.go).
 
 ### Setup
 
-You need:
+In addition to the dependencies listed above under the instructions for running from `rosetta` source code, you also need:
 
-* go >= 1.14
-* rust >= 1.41.0
-* node = 10
-* golangci ([install link](https://golangci-lint.run/usage/install/#local-installation))
 * openapi-generator To re-generate rpc scaffold ([install link](https://openapi-generator.tech))
 
-`Makefile` requires the following env variable to be set and pointed to your local `celo-blockchain` and `celo-monorepo` clones, respectively:
+The `Makefile` requires the following env variable to be set and pointed to your local `celo-blockchain` and `celo-monorepo` clones, respectively. Note that relative paths are fine:
 
 * `CELO_BLOCKCHAIN_PATH`
 * `CELO_MONOREPO_PATH`
@@ -216,7 +229,7 @@ Rosetta requires a few Celo Core Contracts
 
 * The list of required contracts is defined on `scripts/gen-contracts.go` file
 * Generation requires acces to `celo-blockchain` & `celo-monorepo`.
-* Generation assumes both projects are **already properly built**
+* Generation assumes both projects are **already properly built** (see above under instructions for running `rosetta` from source for more details on how to do this)
 * To run generator do `make gen-contracts`
 
 ## How to run rosetta-cli-checks

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You will need the following three repositories cloned locally: `rosetta` (this r
 
 Prerequisites:
 
-* Checkout `celo-monorepo` branch `alfajores` and `yarn && yarn build`
+* Checkout `celo-monorepo` branch `alfajores` and run `yarn && yarn build`
 * Checkout `celo-blockchain` tag `v1.1.1` (NOTE: check that this matches the version specified in the `rosetta` `go.mod` file) and `make all`
 * Export paths to `celo-monorepo` and `celo-blockchain` as `CELO_MONOREPO_PATH` and `CELO_BLOCKCHAIN_PATH` respectively (can be paths relative to `rosetta` repo)
 * Checkout `rosetta` tag `v0.7.5` (or latest released tag) and `make gen-contracts && make all`
@@ -109,7 +109,7 @@ This is the same as above with a few differences (generally: specifying `rc1` vs
 
 Prerequisites:
 
-* Checkout `celo-monorepo` branch `rc1` instead of `alfajores`
+* Checkout `celo-monorepo` branch `rc1` instead of `alfajores`, run `yarn && yarn build` as above
 * `celo-blockchain`: same as above
 * Export paths: same as above
 * Checkout `rosetta`: same as above

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ You will need the following three repositories cloned locally: `rosetta` (this r
 Prerequisites:
 
 * Checkout `celo-monorepo` branch `alfajores` and run `yarn && yarn build`
-* Checkout `celo-blockchain` tag `v1.1.1` (NOTE: check that this matches the version specified in the `rosetta` `go.mod` file) and `make all`
+* Checkout `celo-blockchain` tag `v1.1.2` (NOTE: check that this matches the version specified in the `rosetta` `go.mod` file) and `make all`
 * Export paths to `celo-monorepo` and `celo-blockchain` as `CELO_MONOREPO_PATH` and `CELO_BLOCKCHAIN_PATH` respectively (can be paths relative to `rosetta` repo)
-* Checkout `rosetta` tag `v0.7.5` (or latest released tag) and `make gen-contracts && make all`
+* Checkout `rosetta` tag `v0.7.6` (or latest released tag) and `make gen-contracts && make all`
 * Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service)
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The command below runs the Celo Rosetta RPC server for `alfajores`:
 
 ```bash
 export STATICNODE="enode://e99a883d0b7d0bacb84cde98c4729933b49adbc94e718b77fdb31779c7ed9da6c49236330a9ae096f42bcbf6e803394229120201704b7a4a3ae8004993fa0876@34.83.92.243:30303"
-export RELEASE="0.7.2"
+export RELEASE="latest"  # or specify a release version
 # folder for rosetta to use as data directory (saves rosetta.db & celo-blockchain datadir)
 export DATADIR="${PWD}/datadir"
 mkdir $DATADIR
@@ -147,7 +147,10 @@ docker run --name rosetta --rm \
   -v "${DATADIR}:/data" \
   -p 8080:8080 \
   us.gcr.io/celo-testnet/rosetta:$RELEASE \
-  run --geth.staticnodes $STATICNODE
+  run --geth.staticnodes $STATICNODE \
+  --geth.syncmode full \
+  --geth.gcmode archive
+
 ```
 
 To run this for a different network, replace the genesis block generation and staticnode lines with values specific to the network, as detailed directly below:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Running the Rosetta RPC Server from scratch will take some time to sync, since i
 
 ### Version 1: Running from `rosetta` source code
 
-You will need the following three repositories cloned locally: `rosetta` (this repo), `celo-monorepo`, `celo-blockchain`. You also need: `go >= 1.14`, `rust >= 1.41.0` (blockchain dependency)
+You will need the following three repositories cloned locally: `rosetta` (this repo), [`celo-monorepo`](https://github.com/celo-org/celo-monorepo), [`celo-blockchain`](https://github.com/celo-org/celo-blockchain). You also need: `go >= 1.14`, `rust >= 1.41.0` (blockchain dependency)
 
 #### Running on Alfajores (Testnet)
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,15 @@ Prerequisites:
   ```
 
 * Checkout `rosetta` tag `v0.7.6` (`git fetch --all && git checkout v0.7.6`) (or latest released tag) and `make gen-contracts && make all`
-* Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service)
+* Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service). The output should look something like this:
+
+  ```sh
+  mkdir -p ./envs/alfajores
+  curl 'https://storage.googleapis.com/genesis_blocks/alfajores' > ./envs/alfajores/genesis.json
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                  Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:-100 12600  100 12600    0     0  36842      0 --:--:-- --:--:-- --:--:-- 36842
+  ```
 
 Then run:
 
@@ -130,7 +138,15 @@ Prerequisites:
 * `celo-blockchain`: same as above
 * Export paths: same as above
 * Checkout `rosetta`: same as above
-* Run `make rc1-env` to create an empty datadir with the genesis block
+* Run `make rc1-env` to create an empty datadir with the genesis block. The output should look something like this:
+
+  ```sh
+  mkdir -p ./envs/rc1
+  curl 'https://storage.googleapis.com/genesis_blocks/rc1' > ./envs/rc1/genesis.json
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                  Dload  Upload   Total   Spent    Left  Speed
+  100 25643  100 25643    0     0  56732      0 --:--:-- --:--:-- --:--:-- 56858
+  ```
 
 Then run:
 
@@ -144,7 +160,28 @@ go run main.go run \
   --datadir "./envs/rc1"
 ```
 
+You should start to see continuous output looking similar to this:
+
+```sh
+INFO [01-28|14:09:03.434] Press CTRL-C to stop the process
+INFO [01-28|14:09:03.440] Running geth init                        service=geth
+INFO [01-28|14:09:04.104] Geth Already initialized... skipping init service=geth
+geth --networkid 44787 --nousb --rpc --rpcaddr 127.0.0.1 --rpcport 8545 --rpcvhosts localhost --syncmode full --gcmode archive --rpcapi eth,net,web3,debug,admin,personal --ipcpath <YourPathToRosetta>/rosetta/envs/alfajores/celo/geth.ipc --light.serve 0 --light.maxpeers 0 --maxpeers 1100 --consoleformat term
+INFO [01-28|14:09:05.110] Detected Chain Parameters                chainId=44787 epochSize=17280
+INFO [01-28|14:09:05.120] Starting httpServer                      listen_address=:8080
+INFO [01-28|14:09:05.120] Resuming operation from last persisted  block srv=celo-monitor block=0
+INFO [01-28|14:09:05.121] SubscriptionFetchMode:Start              srv=celo-monitor pipe=header_listener start=1
+
+...
+
+INFO [01-28|14:09:25.731] Stored 1000 blocks                       srv=celo-monitor pipe=persister       block=1000 registryUpdates=0
+```
+
 ### Version 2: Running Rosetta Docker Image
+
+Prerequisites:
+
+* [Install](https://docs.docker.com/engine/install/) and run `docker` (tested with version `19.03.12`)
 
 Rosetta is released as a docker image: `us.gcr.io/celo-testnet/rosetta`. All versions can be found on the [registry page](https://us.gcr.io/celo-testnet/rosetta). Within the docker image, we pack the `rosetta` binary and also the `geth` binary from `celo-blockchain`. Rosetta will run both.
 
@@ -207,7 +244,7 @@ For a code resource, please see the [examples](./examples/airgap/main.go).
 
 In addition to the dependencies listed above under the instructions for running from `rosetta` source code, you also need:
 
-* openapi-generator To re-generate rpc scaffold ([install link](https://openapi-generator.tech))
+* `openapi-generator` To re-generate rpc scaffold ([install link](https://openapi-generator.tech))
 
 The `Makefile` requires the following env variable to be set and pointed to your local `celo-blockchain` and `celo-monorepo` clones, respectively. Note that relative paths are fine:
 
@@ -234,15 +271,16 @@ Rosetta requires a few Celo Core Contracts
 
 ## How to run rosetta-cli-checks
 
-Install the [`rosetta-cli`](https://github.com/coinbase/rosetta-cli) according to the instructions. Current testing has been done with `v0.5.16`.
-
-* Run the Rosetta service in the background for the respective network (currently only alfajores)
-* Run the CLI checks as follows:
+* Install the [`rosetta-cli`](https://github.com/coinbase/rosetta-cli) according to the instructions. (Note that on Mac, installing the `rosetta-cli` to `/usr/local/bin` or adding its location to you `$PATH` will allow you to call `rosetta-cli` directly on the command line rather than needing to provide the path to the executable). Current testing has been done with `v0.5.16` of the `rosetta-cli`.
+* Run the Rosetta service in the background for the respective network (currently only alfajores for both Data and Construction checks)
+* Run the CLI checks for alfajores as follows:
 
 ```sh
 # alfajores; specify construction or data
 rosetta-cli check:construction --configuration-file PATH/TO/rosetta/rosetta-cli-conf/testnet/cli-config.json
 ```
+
+*Note that running the checks to completion will take a long time if this is the first time you are running Rosetta locally. Under the hood, the service is syncing a full archive node, which takes time (likely a couple of days on a normal laptop). The construction service needs to reach the tip before submitting transactions. The data checks will take a while to complete as well (likely a couple of days on a normal laptop with the current settings) as they reconcile balances for the entire chain.*
 
 ### How to generate `bootstrap_balances.json`
 

--- a/README.md
+++ b/README.md
@@ -129,21 +129,11 @@ go run main.go run \
 
 ### Version 2: Running Rosetta Docker Image
 
-**Note:** This is currently slightly out of date, but we are working on getting this up-to-date and improving our release process.
+***Note:** This is currently slightly out of date, but we are working on getting this up-to-date and improving our release process.*
 
-Rosetta is released as a docker image: `us.gcr.io/celo-testnet/rosetta`. All version can be found on the [registry page](https://us.gcr.io/celo-testnet/rosetta)
+Rosetta is released as a docker image: `us.gcr.io/celo-testnet/rosetta`. All version can be found on the [registry page](https://us.gcr.io/celo-testnet/rosetta). Within the docker image, we pack `rosetta` binary and also `geth` binary from celo-blockchain. Rosetta will run both.
 
-Within the docker image, we pack `rosetta` binary and also `geth` binary from celo-blockchain. Rosetta will run both.
-
-To run Rosetta using the docker container, the following options must be configured:
-
-* `genesis.json` for the target network (can be found by `curl 'https://storage.googleapis.com/genesis_blocks/baklava' > genesis.json`)
-* `staticNodes` or `bootnodes`.
-  * With `staticNodes` Rosetta will directly peer to the list of staticNode provided. This node can be any you have access to. For a public list check `https://storage.cloud.google.com/static_nodes/baklava`
-
-Additionaly, it needs a data directory for the geth datadir & rosetta.db
-
-To run Celo Rosetta:
+The command below runs the Celo Rosetta RPC server for `alfajores`:
 
 ```bash
 export STATICNODE="enode://e99a883d0b7d0bacb84cde98c4729933b49adbc94e718b77fdb31779c7ed9da6c49236330a9ae096f42bcbf6e803394229120201704b7a4a3ae8004993fa0876@34.83.92.243:30303"
@@ -159,6 +149,14 @@ docker run --name rosetta --rm \
   us.gcr.io/celo-testnet/rosetta:$RELEASE \
   run --geth.staticnodes $STATICNODE
 ```
+
+To run this for a different network, replace the genesis block generation and staticnode lines with values specific to the network, as detailed directly below:
+
+* `genesis.json` for the target network (can be found by running the following, selecting one of `alfajores`, `baklava`, `rc1` as `<NETWORK>` in `curl 'https://storage.googleapis.com/genesis_blocks/<NETWORK>' > genesis.json`).
+* `staticNodes` or `bootnodes`.
+  * With `staticNodes` Rosetta will directly peer to the list of staticNode provided. This node can be any you have access to. For a public list check `https://storage.cloud.google.com/static_nodes/<NETWORK>`
+
+
 
 ## Airgap Client Guide
 


### PR DESCRIPTION
First pass at updating the README -- still needs some work, but most of the very out-of-date sections have been removed and the instructions for running from source/docker have been updated and should run as expected.