### PR TITLE
Bump celo-blockchain dep -> 1.1.2, release v0.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,8 @@ RUN go build --tags musl -o rosetta .
 # Integrates celo-blockchain & rosetta builds into a single container
 # Outputs: rosetta & geth binaries on /usr/loca/bin
 #---------------------------------------------------------------------
-
-# adbdc7f8c27e50e77b407cb328193bd3ee823643 is mainet(1.0.0) + a few compatible commits that include tracing fix
-# 63ece0c2482b596eac8ad9bc9d3af64e1af99a5a is mainnet(1.1.1) - unknown whether it has the tracing fixes
-FROM us.gcr.io/celo-org/geth:63ece0c2482b596eac8ad9bc9d3af64e1af99a5a
+# geth mainnet (1.1.2)
+FROM us.gcr.io/celo-org/geth:239d0b42be934784ba6a59a03b32ec4aa1895641
 ARG COMMIT_SHA
 
 RUN apk add --no-cache ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 // replace github.com/ethereum/go-ethereum => ../celo-blockchain
 
 // Use this to use external build
-replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.1.1
+replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/celo-org/celo-blockchain v0.0.0-20200612100840-bf2ba25426f9 h1:hBlXuA
 github.com/celo-org/celo-blockchain v0.0.0-20200612100840-bf2ba25426f9/go.mod h1:Ic7V/8BExGs53cByD3Fn9b/F2qjCi6QoDDFSr5aOEQk=
 github.com/celo-org/celo-blockchain v1.1.1 h1:R6w5ckC7J/BfLIBh4qElZ7E55vRZFEdKfkLwTC16M8s=
 github.com/celo-org/celo-blockchain v1.1.1/go.mod h1:/3n/+Rf2pTN4j8qenJ2kAK/yCqKeMoMR2e+X2k42qsU=
+github.com/celo-org/celo-blockchain v1.1.2 h1:cqMAJPe4ND8VE27Nin31O4yEvT/OHemZAhdDHMNbTZw=
+github.com/celo-org/celo-blockchain v1.1.2/go.mod h1:/3n/+Rf2pTN4j8qenJ2kAK/yCqKeMoMR2e+X2k42qsU=
 github.com/celo-org/celo-bls-go v0.1.4 h1:d99spabDiuyMJ4uYa/0MbpCsEhaWSYNIujIoZ5Bu38o=
 github.com/celo-org/celo-bls-go v0.1.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGHIhCB8=

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.7.5"
+	MiddlewareVersion = "0.7.6"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
## Description
Upgrade `celo-blockchain` from 1.1.1 -> 1.1.2, bump Middleware from v0.7.5. -> v0.7.6 accordingly.

## Testing
- Manual testing + `rosetta-cli` checks look as expected for both Docker and source code workflows

## TODOS after PR is merged
- [ ] tag release as v0.7.6
- [ ] publish docker image for the release commit, tag this image