### PR TITLE
Register method StableToken.Transfer

### DIFF
--- a/airgap/api.go
+++ b/airgap/api.go
@@ -59,6 +59,8 @@ type ArgBuilder interface {
 	ReleaseGoldWithdrawGold(releaseGold common.Address, signer common.Address, index *big.Int) (*TxArgs, error)
 	ReleaseGoldRevokePendingVotes(releaseGold common.Address, signer common.Address, group common.Address, value *big.Int) (*TxArgs, error)
 	ReleaseGoldRevokeActiveVotes(releaseGold common.Address, signer common.Address, group common.Address, value *big.Int) (*TxArgs, error)
+
+	StableTokenTransfer(to common.Address, value *big.Int) (*TxArgs, error)
 }
 
 type Client interface {

--- a/airgap/arg_builder.go
+++ b/airgap/arg_builder.go
@@ -119,3 +119,7 @@ func (c *airgapArgBuilderImpl) ReleaseGoldRevokePendingVotes(releaseGold common.
 func (c *airgapArgBuilderImpl) ReleaseGoldRevokeActiveVotes(releaseGold common.Address, signer common.Address, group common.Address, amount *big.Int) (*TxArgs, error) {
 	return c.FillTxArgs(&TxArgs{Method: ReleaseGoldRevokeActiveVotes, To: &releaseGold, From: signer}, signer, group, amount)
 }
+
+func (c *airgapArgBuilderImpl) StableTokenTransfer(to common.Address, value *big.Int) (*TxArgs, error) {
+	return c.FillTxArgs(&TxArgs{Method: StableTokenTransfer, To: &to, Value: value})
+}

--- a/airgap/events.go
+++ b/airgap/events.go
@@ -25,7 +25,7 @@ var (
 	// Election
 	EpochRewardsDistributedToVoters = registerEvent(registry.ElectionContractID.String(), "EpochRewardsDistributedToVoters", []topicParser{addressTopicParser})
 	// StableToken
-	StableTokenTransfer = registerEvent(registry.StableTokenContractID.String(), "Transfer", []topicParser{addressTopicParser, addressTopicParser})
+	StableTokenTransferred = registerEvent(registry.StableTokenContractID.String(), "Transfer", []topicParser{addressTopicParser, addressTopicParser})
 )
 
 type CeloEvent struct {

--- a/airgap/methods.go
+++ b/airgap/methods.go
@@ -72,6 +72,7 @@ var (
 
 	// StableToken
 	StableTokenBalanceOf = registerMethod(registry.StableTokenContractID.String(), "balanceOf", []argParser{addressParser})
+	StableTokenTransfer  = registerMethod(registry.StableTokenContractID.String(), "transfer", []argParser{addressParser, bigIntParser})
 )
 
 // Represents a CeloMethod that can be called with the AirgapClient

--- a/airgap/methods_test.go
+++ b/airgap/methods_test.go
@@ -160,6 +160,13 @@ func TestMethodArgsSerializing(t *testing.T) {
 				big.NewInt(1000),
 			},
 		},
+		{
+			method: StableTokenTransfer,
+			args: []interface{}{
+				common.HexToAddress("0x1111"),
+				big.NewInt(1000),
+			},
+		},
 	}
 
 	for _, _testCase := range testCases {

--- a/airgap/server/events.go
+++ b/airgap/server/events.go
@@ -25,7 +25,7 @@ import (
 
 var serverCallEventDefinitions = []*airgap.CeloEvent{
 	airgap.EpochRewardsDistributedToVoters,
-	airgap.StableTokenTransfer,
+	airgap.StableTokenTransferred,
 }
 
 func hydrateEvents(srvCtx ServerContext, events []*airgap.CeloEvent) (map[*airgap.CeloEvent]airGapServerEvent, error) {

--- a/airgap/server/methods.go
+++ b/airgap/server/methods.go
@@ -61,6 +61,8 @@ var serverTransactionMethodDefinitions = map[*airgap.CeloMethod]argsPreProcessor
 	airgap.ReleaseGoldAuthorizeValidatorSigner:   preprocessAuthorizeSigner,
 	airgap.ReleaseGoldRevokePendingVotes:         preprocessRevoke,
 	airgap.ReleaseGoldRevokeActiveVotes:          preprocessRevoke,
+
+	airgap.StableTokenTransfer: noopArgsPreProcessor,
 }
 
 var serverCallMethodDefinitions = map[*airgap.CeloMethod]argsPreProcessor{

--- a/airgap/server/methods_test.go
+++ b/airgap/server/methods_test.go
@@ -43,6 +43,8 @@ func TestMethodArgumentParsing(t *testing.T) {
 		{airgap.UnlockGold, []interface{}{big.NewInt(100)}},
 		{airgap.RelockGold, []interface{}{big.NewInt(1), big.NewInt(100)}},
 		{airgap.WithdrawGold, []interface{}{big.NewInt(1)}},
+
+		{airgap.StableTokenTransfer, []interface{}{common.HexToAddress("0x1234"), big.NewInt(1)}},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Tiny PR to register the `StableToken.Transfer` method + add to `ArgBuilder. Also renames the `StableToken.Transfer` event (internal variable) to `StableTokenTransferred` to hopefully make the distinction a bit clearer.

Separated this from other Construction API work (currently on branch `beta/construction`) to try to isolate only breaking changes in the beta branch.