### PR TITLE
Update cloudbuild to push release tags

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,16 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/rosetta:$COMMIT_SHA', '--build-arg', 'COMMIT_SHA=$COMMIT_SHA', '.' ]
+  args: [
+    'build',
+    '-t', 'us.gcr.io/$PROJECT_ID/rosetta:$COMMIT_SHA',
+    '-t', 'us.gcr.io/$PROJECT_ID/rosetta:$TAG_NAME',
+    '-t', 'us.gcr.io/$PROJECT_ID/rosetta:latest',
+    '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
+    '.',
+    ]
   waitFor: ["-"]
 images:
 - 'us.gcr.io/$PROJECT_ID/rosetta:$COMMIT_SHA'
+- 'us.gcr.io/$PROJECT_ID/rosetta:$TAG_NAME'
+- 'us.gcr.io/$PROJECT_ID/rosetta:latest'
 timeout: 2700s


### PR DESCRIPTION
Update `cloudbuild.yaml` to build and tag docker images according to release tag (and `latest`). This will automate the Docker image part of the release process.

Closes #135