### PR TITLE
Bump blockchain to 1.2.2 and bump middleware version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN go build --tags musl -o rosetta .
 # Integrates celo-blockchain & rosetta builds into a single container
 # Outputs: rosetta & geth binaries on /usr/loca/bin
 #---------------------------------------------------------------------
-# geth mainnet (1.1.2)
-FROM us.gcr.io/celo-org/geth:239d0b42be934784ba6a59a03b32ec4aa1895641
+# geth mainnet (1.2.2)
+FROM us.gcr.io/celo-org/geth:dba095d2aea40e3ae5da65392de3b3b44105651b
 ARG COMMIT_SHA
 
 RUN apk add --no-cache ca-certificates

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Prerequisites:
   export CELO_BLOCKCHAIN_PATH=path/to/celo-blockchain
   ```
 
-* Checkout `rosetta` tag `v0.7.6` (`git fetch --all && git checkout v0.7.6`) (or latest released tag) and `make gen-contracts && make all`
+* Checkout `rosetta` tag `v0.7.7` (`git fetch --all && git checkout v0.7.7`) (or latest released tag) and `make gen-contracts && make all`
 * Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service). The output should look something like this:
 
   ```sh

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 // replace github.com/ethereum/go-ethereum => ../celo-blockchain
 
 // Use this to use external build
-replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.1.2
+replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
+github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
 github.com/celo-org/bls-zexe/go v0.0.0-20200502082044-230d2f4866d5 h1:9tRTgwOba1uX4OpX8w0w/F3F0SwrkhGnrjsr6Qs65eo=
 github.com/celo-org/bls-zexe/go v0.0.0-20200502082044-230d2f4866d5/go.mod h1:CzbB0Yl65q4G1bsLEZGKW+wTLdIInCLLXyJSL7IZqnk=
 github.com/celo-org/celo-blockchain v0.0.0-20200612100840-bf2ba25426f9 h1:hBlXuAwnR62EHo1xHSoXcG6CYWwSL5YWArRhKneWzJU=
@@ -75,6 +77,8 @@ github.com/celo-org/celo-blockchain v1.1.1 h1:R6w5ckC7J/BfLIBh4qElZ7E55vRZFEdKfk
 github.com/celo-org/celo-blockchain v1.1.1/go.mod h1:/3n/+Rf2pTN4j8qenJ2kAK/yCqKeMoMR2e+X2k42qsU=
 github.com/celo-org/celo-blockchain v1.1.2 h1:cqMAJPe4ND8VE27Nin31O4yEvT/OHemZAhdDHMNbTZw=
 github.com/celo-org/celo-blockchain v1.1.2/go.mod h1:/3n/+Rf2pTN4j8qenJ2kAK/yCqKeMoMR2e+X2k42qsU=
+github.com/celo-org/celo-blockchain v1.2.2 h1:3gEgGjkUk6cdlpJg7qruoeONUMNvakQJSGDCIFRtE8A=
+github.com/celo-org/celo-blockchain v1.2.2/go.mod h1:SPXvHaURkjPybfqabXf159vDuo2SCHusO0lIImwqoHY=
 github.com/celo-org/celo-bls-go v0.1.4 h1:d99spabDiuyMJ4uYa/0MbpCsEhaWSYNIujIoZ5Bu38o=
 github.com/celo-org/celo-bls-go v0.1.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGHIhCB8=

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.7.6"
+	MiddlewareVersion = "0.7.7"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
- Middleware version from 0.7.6 -> 0.7.7
- Blockchain version from 1.1.2 -> 1.2.2 (stable)
