### PR TITLE
Fix bug for edge case: locking 0 CELO

### DIFF
--- a/analyzer/txtracer.go
+++ b/analyzer/txtracer.go
@@ -281,8 +281,11 @@ func (tr *Tracer) TxOpsFromLogs(tx *types.Transaction, receipt *types.Receipt, t
 			case "GoldLocked":
 				// lock() [GoldLocked + transfer] => main->lockNonVoting
 				event := eventRaw.(*contracts.LockedGoldGoldLocked)
-				transfers = append(transfers, *NewLockGold(event.Account, lockedGoldAddr, event.Value))
-
+				// Edge case: locking 0 CELO means there isn't a matching transfer;
+				// Only store balance-changing (>0) GoldLocked logs.
+				if event.Value.Cmp(big.NewInt(0)) > 0 {
+					transfers = append(transfers, *NewLockGold(event.Account, lockedGoldAddr, event.Value))
+				}
 			case "GoldRelocked":
 				// relock() [GoldRelocked] => lockPending->lockNonVoting
 				event := eventRaw.(*contracts.LockedGoldGoldRelocked)


### PR DESCRIPTION
Background:
- A few transactions were failing on alfajores (ex -> `0x9466e0b9d70fcbcc7d74b7c3bd55132b501e52885942f64d6b708010fd9e49fb` in block `3759062`)
- Turns out these were `LockedGold.lock` txs with no CELO locked (value = 0), therefore no CELO was transferred. Since the event showed up in the event logs but there was no transfer, this caused the transfer/event log reconciliation to fail and not return any of the broken down operations for the given transaction (i.e. gas fees, etc.).
- I don't think this edge case applies to the other locked gold cases where transfer reconciliation happens)

Proposed fix (in this PR):
- Rather than adding in support within the log reconciliation, we simply don't register `GoldLocked` events where the value of the event was 0. This isn't a balance-changing op, so should be ok.
- The alternative would be displaying an op like `LockGold` with value 0, which is technically consistent with behavior for `GoldRelocked` which displays a relocked value of 0 under ops; downside here is it requires more handling within the actual log/transfer reconciliation that happens within `ReconcileLogOpsWithTransfers`, which means a lot more that could go wrong/have unintended consequences here. (It would also be possible to change this behavior for the other locking ops.)

Other locked gold cases?
- looks like GoldLocked is the only one for which this particular edge case (0-locking) causes Rosetta to break (special handling within `MatchAndReconcileLogOpWithTransfer`, + some manual testing)
- manually tested `GoldRelocked`, `GoldUnlocked`
- haven't been able to manually test `GoldWithdrawn` as yet because of the time constraint on withdrawing, nor AccountsSlashed
- unsure about `AccountsSlashed`, `GoldWithdrawn