### PR TITLE
Bump blockchain version to 1.2.4, release v0.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN go build --tags musl -o rosetta .
 # Integrates celo-blockchain & rosetta builds into a single container
 # Outputs: rosetta & geth binaries on /usr/loca/bin
 #---------------------------------------------------------------------
-# geth mainnet (1.2.2)
-FROM us.gcr.io/celo-org/geth:dba095d2aea40e3ae5da65392de3b3b44105651b
+# geth mainnet (1.2.4)
+FROM us.gcr.io/celo-org/geth:8ae8f032979aba42ad64a0ba67a3a5585dd9c63b
 ARG COMMIT_SHA
 
 RUN apk add --no-cache ca-certificates

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Prerequisites:
   export CELO_BLOCKCHAIN_PATH=path/to/celo-blockchain
   ```
 
-* Checkout `rosetta` tag `v0.7.8` (`git fetch --all && git checkout v0.7.8`) (or latest released tag) and `make gen-contracts && make all`
+* Checkout `rosetta` tag `v0.8.0` (`git fetch --all && git checkout v0.8.0`) (or latest released tag) and `make gen-contracts && make all`
 * Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service). The output should look something like this:
 
   ```sh

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 // replace github.com/ethereum/go-ethereum => ../celo-blockchain
 
 // Use this to use external build
-replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.2.2
+replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/celo-org/celo-blockchain v1.1.2 h1:cqMAJPe4ND8VE27Nin31O4yEvT/OHemZAh
 github.com/celo-org/celo-blockchain v1.1.2/go.mod h1:/3n/+Rf2pTN4j8qenJ2kAK/yCqKeMoMR2e+X2k42qsU=
 github.com/celo-org/celo-blockchain v1.2.2 h1:3gEgGjkUk6cdlpJg7qruoeONUMNvakQJSGDCIFRtE8A=
 github.com/celo-org/celo-blockchain v1.2.2/go.mod h1:SPXvHaURkjPybfqabXf159vDuo2SCHusO0lIImwqoHY=
+github.com/celo-org/celo-blockchain v1.2.4 h1:jOlNfk2FZzaPzYPOGQvmkRGa3UYMUue/mxp/CXC8vyU=
+github.com/celo-org/celo-blockchain v1.2.4/go.mod h1:SPXvHaURkjPybfqabXf159vDuo2SCHusO0lIImwqoHY=
 github.com/celo-org/celo-bls-go v0.1.4 h1:d99spabDiuyMJ4uYa/0MbpCsEhaWSYNIujIoZ5Bu38o=
 github.com/celo-org/celo-bls-go v0.1.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGHIhCB8=

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.7.8"
+	MiddlewareVersion = "0.8.0"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
Security patch in `celo-blockchain` version 1.2.4

closes #156 