### PR TITLE
Fix error logging to not modify underlying object

### DIFF
--- a/service/rpc/errors.go
+++ b/service/rpc/errors.go
@@ -61,10 +61,12 @@ func LogErrUnimplemented(rosettaEndpoint string) *types.Error {
 }
 
 func LogErrDetails(rosettaErr *types.Error, err error) *types.Error {
-	rosettaErr.Details = map[string]interface{}{
+	copyErr := &types.Error{}
+	*copyErr = *rosettaErr
+	copyErr.Details = map[string]interface{}{
 		"context": err.Error(),
 	}
-	return rosettaErr
+	return copyErr
 }
 
 func LogErrInternal(err error, params ...interface{}) *types.Error {

--- a/service/rpc/errors_test.go
+++ b/service/rpc/errors_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rpc
 
 import (

--- a/service/rpc/errors_test.go
+++ b/service/rpc/errors_test.go
@@ -1,0 +1,32 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestLogErrDetails(t *testing.T) {
+	RegisterTestingT(t)
+
+	errCode := int32(-111)
+	errMsg := "Fake Error"
+	testErr := errors.New("test error")
+
+	rosettaErr := NewErrorResponse(errCode, errMsg)
+	copyErr := NewErrorResponse(errCode, errMsg)
+	loggedErr := LogErrDetails(rosettaErr, testErr)
+
+	t.Run("Error details populated", func(t *testing.T) {
+		Ω(loggedErr).ShouldNot(Equal(copyErr))
+		copyLoggedErr := *loggedErr
+		copyLoggedErr.Details = nil
+		Ω(*loggedErr).ShouldNot(Equal(copyLoggedErr))
+		Ω(copyLoggedErr).Should(Equal(*copyErr))
+	})
+
+	t.Run("Logging doesn't change original arg", func(t *testing.T) {
+		Ω(rosettaErr).Should(Equal(copyErr))
+	})
+}


### PR DESCRIPTION
# Description
CLI checks were failing because details were being populated in `network/options` (if an error had been logged at some point). Reason: we were modifying the `Err*` vars and then logging the details, fix here is to create a copy of the error + modify+log this copy.

Incidentally seems to fix #155 as well.

# Testing
- Adds a unit test for the `LogErrDetails` function
- Fixes asserter error when restarting CLI