### PR TITLE
Fix args on starting geth service for donut

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You also need the following dependencies to be met:
 Prerequisites:
 
 - Checkout `celo-blockchain` tag `v1.3.2` (`git fetch --all && git checkout v1.3.2`) (NOTE: check that this matches the version specified in `rosetta`'s `go.mod` file) and `make geth`
-- Checkout `rosetta` tag `v0.8.3` (`git fetch --all && git checkout v0.8.3`) (or latest released tag) and `make all`
+- Checkout `rosetta` tag `v0.8.4` (`git fetch --all && git checkout v0.8.4`) (or latest released tag) and `make all`
 - Run `make alfajores-env` to create an empty datadir with the genesis block (only needs to be run the first time, upon initializing the service). The output should look something like this:
 
   ```sh

--- a/service/geth/geth.go
+++ b/service/geth/geth.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 
 	"github.com/celo-org/celo-blockchain/log"
+	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/kliento/utils/chain"
 	"github.com/celo-org/rosetta/internal/fileutils"
 	"github.com/celo-org/rosetta/service"
@@ -194,7 +195,6 @@ func (gs *gethService) ensureGethInit() error {
 
 func (gs *gethService) startGeth(stdErr *os.File) error {
 	gethArgs := []string{
-		"--networkid", gs.chainParams.ChainId.String(),
 		"--nousb",
 		"--rpc",
 		"--rpcaddr", gs.opts.RpcAddr,
@@ -209,6 +209,19 @@ func (gs *gethService) startGeth(stdErr *os.File) error {
 		"--maxpeers", "1100",
 		"--consoleformat", "term",
 		// "--consoleoutput", "split",
+	}
+
+	switch gs.chainParams.ChainId.String() {
+	case params.AlfajoresChainConfig.ChainID.String():
+		gethArgs = append([]string{"--alfajores"}, gethArgs...)
+	case params.BaklavaChainConfig.ChainID.String():
+		gethArgs = append([]string{"--baklava"}, gethArgs...)
+	case params.MainnetChainConfig.ChainID.String():
+		break
+	default:
+		chainErr := fmt.Errorf("unknown ChainID: %s", gs.chainParams.ChainId.String())
+		gs.logger.Error("Error configuring geth args", "err", chainErr)
+		return chainErr
 	}
 
 	if gs.opts.Verbosity != "" {

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.8.3"
+	MiddlewareVersion = "0.8.4"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
- change in `networkid` param was causing node to not to actually fork in donut
- temp fix to just set the flag to `--alfajores`, `--baklava`, or nothing (for mainnet) accordingly
- bump release versions to get a new version out asap