### PR TITLE
Piersy/update kliento for celo blockchain v1.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN go build --tags musl -o rosetta .
 # Outputs: rosetta & geth binaries on /usr/loca/bin
 #---------------------------------------------------------------------
 # geth mainnet (1.5.1)
-FROM us.gcr.io/celo-org/geth:1.5.1
+FROM us.gcr.io/celo-org/geth:1.5.4
 ARG COMMIT_SHA
 
 RUN apk add --no-cache ca-certificates

--- a/README.md
+++ b/README.md
@@ -95,50 +95,29 @@ You also need the following dependencies to be met:
 - `go >= 1.15`
 - `golangci` ([installation instructions](https://golangci-lint.run/usage/install/#local-installation)) (linter dependency for the Makefile)
 
-#### Running on Alfajores (Testnet)
+#### Running Rosetta
 
 Prerequisites:
 
-- Checkout `celo-blockchain` tag `v1.5.1` (`git fetch --all && git checkout v1.5.1`) (NOTE: check that this matches the version specified in `rosetta`'s `go.mod` file) and `make geth`
-- Checkout `rosetta` tag `v0.8.5` (`git fetch --all && git checkout v0.8.5`) (or latest released tag) and `make all`
-- Replace `<PATH-TO-DATADIR>` below, which is the location for the alfajores data directory (the directory does not need to exist before passing it in)
+- Checkout the rosetta version that you want and run `make all`.
+- Find the `celo-blockchain` version in the rosetta `go.mod` file. Look for a line containing `github.com/celo-org/celo-blockchain` the version comes after separated by a space.
+- Checkout `celo-blockchain` at the version specified in rosetta's `go.mod` and run `make geth`
+- Replace `<NETWORK>` with one of `alfajores` (developer testnet), `baklava` (validator testnet) or `mainnet`.
+- Replace `<PATH-TO-DATADIR>` below, which is the location for the celo-blockchain data directory (the directory does not need to exist before passing it in).
+The data directory is network specific so when switching networks you will also need to change the data directory.
 
 Then run:
 
 ```bash
 go run main.go run \
-  --geth.network alfajores \
+  --geth.network <NETWORK> \
   --geth.binary ../celo-blockchain/build/bin/geth \
   --geth.syncmode full \
   --geth.gcmode archive \
   --datadir <PATH-TO-DATADIR>
 ```
 
-You can stop the service and restart by re-running just the last command above (`go run main.go` ... )
-
-#### Running on Mainnet
-
-This is the same as above with a few differences (generally: specifying `mainnet` vs. `alfajores`)
-
-Prerequisites:
-
-- `celo-blockchain`: same as above
-- Export paths: same as above
-- Checkout `rosetta`: same as above
-- Replace `<PATH-TO-DATADIR>` below, which is the location for the mainnet data directory (the directory does not need to exist before passing it in)
-
-Then run:
-
-```bash
-go run main.go run \
-  --geth.network mainnet \
-  --geth.binary ../celo-blockchain/build/bin/geth \
-  --geth.syncmode full \
-  --geth.gcmode archive \
-  --datadir <PATH-TO-DATADIR>
-```
-
-You should start to see continuous output looking similar to this:
+You should start to see continuous output looking something like this:
 
 ```sh
 INFO [01-28|14:09:03.434] Press CTRL-C to stop the process
@@ -152,6 +131,8 @@ INFO [01-28|14:09:05.121] SubscriptionFetchMode:Start              srv=celo-moni
 
 INFO [01-28|14:09:25.731] Stored 1000 blocks                       srv=celo-monitor pipe=persister       block=1000 registryUpdates=0
 ```
+
+You can stop the service and restart by re-running just the last command above (`go run main.go` ... )
 
 ### Version 2: Running Rosetta Docker Image
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/allegro/bigcache v1.2.1 // indirect
-	github.com/celo-org/celo-blockchain v1.5.1
-	github.com/celo-org/kliento v0.2.1-0.20220128184937-bfd9c57b26e9
+	github.com/celo-org/celo-blockchain v1.5.4
+	github.com/celo-org/kliento v0.2.1-0.20220301112806-fb1968d272c2
 	github.com/coinbase/rosetta-sdk-go v0.5.9
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/gorilla/handlers v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -88,12 +88,12 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
-github.com/celo-org/celo-blockchain v1.5.1 h1:o/QAVKBownPaZuXbW+c1SW3ivGvc5vhLjwpzwahplIk=
-github.com/celo-org/celo-blockchain v1.5.1/go.mod h1:j18Hg9JZeOg6d5pbFC8Y5ykt1NDs9lmHesyHd91r0PE=
+github.com/celo-org/celo-blockchain v1.5.4 h1:FUdTkegJZx5MwK4juMgDodpA1OOirey8HvUsqS7A6mA=
+github.com/celo-org/celo-blockchain v1.5.4/go.mod h1:j18Hg9JZeOg6d5pbFC8Y5ykt1NDs9lmHesyHd91r0PE=
 github.com/celo-org/celo-bls-go v0.2.4 h1:V1y92kM5IRJWQZ6DCwqiKLW7swmUA5y/dPJ9YbU4HfA=
 github.com/celo-org/celo-bls-go v0.2.4/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
-github.com/celo-org/kliento v0.2.1-0.20220128184937-bfd9c57b26e9 h1:qLW2Thwx7Fx7J5pq9myZjIhlByOWzUiT3R7tfiH5VGM=
-github.com/celo-org/kliento v0.2.1-0.20220128184937-bfd9c57b26e9/go.mod h1:0WuDZOE5zK0PZniFcJyn36G79EWykGn7K0kJD0BnYCA=
+github.com/celo-org/kliento v0.2.1-0.20220301112806-fb1968d272c2 h1:eVkrAvceM07Th1n1drLwZYeRdL+xkPUXVRz+dekcbuA=
+github.com/celo-org/kliento v0.2.1-0.20220301112806-fb1968d272c2/go.mod h1:H/MBXntXRVilGnGuBb197O1epsMe/Im9xYGMFNZIxoU=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
This PR updates the version of kliento used by rosetta to a version that uses celo-blockchain v1.5.4.

It also adjusts the README instructions for running such that they should not need to be changed with every release.