### PR TITLE
Increase default request (&tracing) timeout to 120s

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Flags:
   -h, --help                      help for run
       --rpc.address string        Listening address for http server
       --rpc.port uint             Listening port for http server (default 8080)
-      --rpc.reqTimeout duration   Timeout for requests to this service, this also controls the timeout sent to the blockchain node for trace transaction requests (default 25s)
+      --rpc.reqTimeout duration   Timeout for requests to this service, this also controls the timeout sent to the blockchain node for trace transaction requests (default 2m0s)
 ```
 
 Every argument can be defined using environment variables using `ROSETTA_` prefix; and replacing `.` for `_`; for example:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,7 +64,7 @@ func init() {
 	// RPC Service Flags
 	flagSet.Uint("rpc.port", 8080, "Listening port for http server")
 	flagSet.String("rpc.address", "", "Listening address for http server")
-	flagSet.Duration("rpc.reqTimeout", 25*time.Second, "Timeout for requests to this service, this also controls the timeout sent to the blockchain node for trace transaction requests")
+	flagSet.Duration("rpc.reqTimeout", 120*time.Second, "Timeout for requests to this service, this also controls the timeout sent to the blockchain node for trace transaction requests")
 
 	// Geth Service Flags
 	flagSet.String("geth.binary", "", "Path to the celo-blockchain binary")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ var Node NodeConfig
 
 func configureDefaults() {
 	// httpServer
-	viper.SetDefault("httpServer.requestTimeout", "25s")
+	viper.SetDefault("httpServer.requestTimeout", "120s")
 	viper.SetDefault("httpServer.port", "8080")
 	viper.SetDefault("httpServer.interface", "")
 


### PR DESCRIPTION
This value should allow tracing of all transactions without facing a
timeout. It's not a guarantee since hardware and a node's current load
will also affect tracing time.

Relates to #180