### PR TITLE
Set middleware version for release

### DIFF
--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "0.8.5"
+	MiddlewareVersion = "0.9.1"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
I failed to set the middleware version for the last release, so I need to re-release with a corrected middleware version.