### PR TITLE
Fix signing in airgap

### DIFF
--- a/airgap/client.go
+++ b/airgap/client.go
@@ -53,7 +53,7 @@ func (c *clientImpl) Derive(privateKey *ecdsa.PrivateKey) (*ecdsa.PublicKey, *co
 // Sign signs an arbitrary message with the private key the returned signature
 // as 64 bytes long and in the [R || S] format.
 func (c *clientImpl) Sign(message []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
-	// crypto.Sigh produces signatures in the [ R || S || V ] format, but the
+	// crypto.Sign produces signatures in the [ R || S || V ] format, but the
 	// signatures returned by this method are not used for recovery and so the
 	// recovery byte is removed.
 	sig, err := crypto.Sign(crypto.Keccak256(message), privateKey)
@@ -68,7 +68,7 @@ func (c *clientImpl) Verify(message []byte, publicKey *ecdsa.PublicKey, signatur
 	return crypto.VerifySignature(crypto.FromECDSAPub(publicKey), crypto.Keccak256(message), signature)
 }
 
-// ConstructTxFromMetadata creates a new transaction using given Metadata
+// ConstructTxFromMetadata creates a new transaction using given metadata.
 func (c *clientImpl) ConstructTxFromMetadata(tm *TxMetadata) (*Transaction, error) {
 	return &Transaction{
 		TxMetadata: tm,
@@ -93,12 +93,12 @@ func (c *clientImpl) SignTx(tx *Transaction, privateKey *ecdsa.PrivateKey) (*Tra
 	return tx, nil
 }
 
-// GenerateProofOfPossessionSignature generates a recoverable (65 byte) ecdsa
+// GenerateProofOfPossessionSignature generates a recoverable (65 byte) ECDSA
 // signature over the given address using the given privateKey. The signature
-// is used to authorize release gold operrations on chain. The signature
+// is used to authorize release gold operations on chain. The signature
 // returned is in the [ R || S || V ] format where V is 27 or 28. This is a
-// stange hangover from Bitcoin and is required becuase the precompiled
-// ecrecover contract in the evm expects this format.
+// strange hangover from Bitcoin and is required because the precompiled
+// ecrecover contract in the EVM expects this format.
 //
 // See explanation for this format here:
 // https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739

--- a/airgap/client.go
+++ b/airgap/client.go
@@ -52,10 +52,10 @@ func (c *clientImpl) Derive(privateKey *ecdsa.PrivateKey) (*ecdsa.PublicKey, *co
 
 // Sign an arbitrary message with the private key
 func (c *clientImpl) Sign(message []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
-	return c.SignHash(crypto.Keccak256(message), privateKey)
+	return c.signHash(crypto.Keccak256(message), privateKey)
 }
 
-func (c *clientImpl) SignHash(digest []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+func (c *clientImpl) signHash(digest []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
 	sig, err := crypto.Sign(digest, privateKey)
 	if err != nil {
 		// see https://github.com/celo-org/celo-blockchain/blob/0792a7189b531e22b97b81b6d6aa29301c3ebb8e/internal/ethapi/api.go#L1613
@@ -64,16 +64,12 @@ func (c *clientImpl) SignHash(digest []byte, privateKey *ecdsa.PrivateKey) ([]by
 	return sig, err
 }
 
-func (c *clientImpl) SignWithPrefix(message []byte, privateKey *ecdsa.PrivateKey) ([]byte, error) {
-	return c.SignHash(accounts.TextHash(message), privateKey)
-}
-
 // Verify the signature of an arbitrary message
 func (c *clientImpl) Verify(message []byte, publicKey *ecdsa.PublicKey, signature []byte) bool {
-	return c.VerifyHash(crypto.Keccak256(message), publicKey, signature)
+	return c.verifyHash(crypto.Keccak256(message), publicKey, signature)
 }
 
-func (c *clientImpl) VerifyHash(digest []byte, publicKey *ecdsa.PublicKey, signature []byte) bool {
+func (c *clientImpl) verifyHash(digest []byte, publicKey *ecdsa.PublicKey, signature []byte) bool {
 	if signature[crypto.RecoveryIDOffset] != 27 && signature[crypto.RecoveryIDOffset] != 28 {
 		return false
 	}
@@ -84,7 +80,7 @@ func (c *clientImpl) VerifyHash(digest []byte, publicKey *ecdsa.PublicKey, signa
 }
 
 func (c *clientImpl) VerifyWithPrefix(message []byte, publicKey *ecdsa.PublicKey, signature []byte) bool {
-	return c.VerifyHash(accounts.TextHash(message), publicKey, signature)
+	return c.verifyHash(accounts.TextHash(message), publicKey, signature)
 }
 
 // ConstructTxFromMetadata creates a new transaction using given Metadata
@@ -113,7 +109,7 @@ func (c *clientImpl) SignTx(tx *Transaction, privateKey *ecdsa.PrivateKey) (*Tra
 }
 
 func (c *clientImpl) GenerateProofOfPossessionSignature(privateKey *ecdsa.PrivateKey, address *common.Address) ([]byte, error) {
-	return c.SignWithPrefix(address.Bytes(), privateKey)
+	return c.signHash(accounts.TextHash(address.Bytes()), privateKey)
 }
 
 var abiParsers = map[string]func() (*abi.ABI, error){


### PR DESCRIPTION
Singing was broken for coinbase.

Sign and Verify were not working because Sign was creating a 65 byte
signature with a 0 or 1 recovery id and Verify expected a 64 byte
signature with no recovery id.

GenerateProofOfPossessionSignature was also not functioning correctly
because the sign logic was failing to modify the signature recovery byte
to be 27 or 28 which is expected by the ecrecover evm contract.

Now Sign and Verify have been updated to produce and consume 64 byte
ecdsa signatures without a recovery byte.

GenerateProofOfPossessionSignature now correctly sets the recovery byte
to be either 27 or 28.

Also removed VerifyWithPrefix as it was not used.
