### PR TITLE
[fix] process failed tx as failed operations

### DIFF
--- a/analyzer/txtracer.go
+++ b/analyzer/txtracer.go
@@ -86,34 +86,32 @@ func (tr *Tracer) TraceTransaction(blockHeader *types.Header, tx *types.Transact
 		ops = append(ops, *gasOp)
 	}
 
-	if receipt.Status == types.ReceiptStatusSuccessful {
-		contractMap, err := tr.GetRegistryAddresses(receipt, registry.ReserveContractID.String(), registry.LockedGoldContractID.String(), registry.ElectionContractID.String(), registry.GovernanceContractID.String(), registry.AccountsContractID.String())
-		if err != nil {
-			return nil, err
-		}
-
-		tobinTax, err := tr.GetTobinTax(receipt.BlockNumber, contractMap[registry.ReserveContractID.String()])
-		if err != nil {
-			return nil, err
-		}
-
-		logOps, err := tr.TxOpsFromLogs(tx, receipt, tobinTax, contractMap)
-		if err != nil {
-			return nil, err
-		}
-
-		transferOps, err := tr.TxTransfers(tx, receipt, tobinTax)
-		if err != nil {
-			return nil, err
-		}
-
-		reconciledOps, err := ReconcileLogOpsWithTransfers(logOps, transferOps, tobinTax, contractMap[registry.LockedGoldContractID.String()])
-		if err != nil {
-			return nil, err
-		}
-
-		ops = append(ops, reconciledOps...)
+	contractMap, err := tr.GetRegistryAddresses(receipt, registry.ReserveContractID.String(), registry.LockedGoldContractID.String(), registry.ElectionContractID.String(), registry.GovernanceContractID.String(), registry.AccountsContractID.String())
+	if err != nil {
+		return nil, err
 	}
+
+	tobinTax, err := tr.GetTobinTax(receipt.BlockNumber, contractMap[registry.ReserveContractID.String()])
+	if err != nil {
+		return nil, err
+	}
+
+	logOps, err := tr.TxOpsFromLogs(tx, receipt, tobinTax, contractMap)
+	if err != nil {
+		return nil, err
+	}
+
+	transferOps, err := tr.TxTransfers(tx, receipt, tobinTax)
+	if err != nil {
+		return nil, err
+	}
+
+	reconciledOps, err := ReconcileLogOpsWithTransfers(logOps, transferOps, tobinTax, contractMap[registry.LockedGoldContractID.String()])
+	if err != nil {
+		return nil, err
+	}
+
+	ops = append(ops, reconciledOps...)
 
 	return ops, nil
 }
@@ -162,10 +160,6 @@ func (tr *Tracer) TxGasDetails(coinbase common.Address, tx *types.Transaction, r
 }
 
 func (tr *Tracer) TxTransfers(tx *types.Transaction, receipt *types.Receipt, tobinTax *TobinTax) ([]Operation, error) {
-	if receipt.Status == types.ReceiptStatusFailed {
-		return nil, nil
-	}
-
 	res := debug.TransferTracerResponse{}
 	timeout := tr.traceTimeout.String()
 	cfg := &tracers.TraceConfig{Tracer: &debug.TransferTracer, Timeout: &timeout}


### PR DESCRIPTION
Currently when a transaction fails/reverts we are not returning operations based on on receipt status.
Current code executes 
```
if receipt.Status == types.ReceiptStatusSuccessful {
  // create operations
}
```
What the ideal behavior is if the transaction is reverted then we send the operation with status as failed.

This PR removes adds a `failed` check and let it execute all the methods.
From what I can see `GetRegistryAddresses` and `GetTobinTax` will execute as they don't really depend on status.

`TxOpsFromLogs` - this will not be needed as for failed tx, there would be no logs? (Is that the correct behavior?)

`TxTransfers`
I removed the check 
```
if receipt.Status == types.ReceiptStatusFailed {
		return nil, nil
	}
```
since I believe we will be able to get trace of the failed tx and then `InternalTransfersToOperations` method will mark the tx as failed and this will return back a failed operation. 

`ReconcileLogOpsWithTransfers` is not needed since we are not matching trace with logs since tx is failed.


Please take a look and let me know if any of above assumptions are wrong are wrong.
