### PR TITLE
Update readme with release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ Rosetta uses [kliento](https://github.com/celo-org/kliento) to interact with the
 ## How to run rosetta-cli-checks
 
 _Note that running these checks is most likely infeasible for most people on
-mainnet because you will need at least 1.5 terrabytes of space and several days
-to be able to sync the chain. Under the hood, the service is syncing a full
-archive node, which takes a long time. The construction service needs to reach
-the tip before submitting transactions. The data checks will take a while to
-complete as well (likely a couple of days on a normal laptop with the current
-settings) as they reconcile balances for the entire chain._
+mainnet because you will need at least 1.5 terrabytes (as of 2022/11) of space
+and several days to be able to sync the chain. Under the hood, the service is
+syncing a full archive node, which takes a long time. The construction service
+needs to reach the tip before submitting transactions. The data checks will
+take a while to complete as well (likely a couple of days on a normal laptop
+with the current settings) as they reconcile balances for the entire chain._
 
 - Install the [`rosetta-cli`](https://github.com/coinbase/rosetta-cli) according to the instructions. (Note that on Mac, installing the `rosetta-cli` to `/usr/local/bin` or adding its location to you `$PATH` will allow you to call `rosetta-cli` directly on the command line rather than needing to provide the path to the executable). Current testing has been done with `v0.5.16` of the `rosetta-cli`.
 - Run the Rosetta service in the background for the respective network (currently only alfajores for both Data and Construction checks)

--- a/README.md
+++ b/README.md
@@ -208,3 +208,56 @@ go run examples/generate_balances/main.go \
   https://storage.googleapis.com/genesis_blocks/alfajores \
   rosetta-cli-conf/testnet/bootstrap_balances.json
 ```
+
+## Releasing rosetta
+
+### Versioning
+
+Rosetta uses [semantic versioning](https://semver.org/) and contains 3 distinct
+interfaces that should be taken into account when setting the version. Having
+so many interfaces exported from this repo makes it likely that most changes
+will constitute a breaking change in at least one interface.
+
+* The rosetta HTTP API exposed by the services in this repo.
+* The CLI exposed by the rosetta binary.
+* All exported code in the repo, since this repo is imported as a module by Coinbase projects.
+
+Breaking changes constitute any change that could cause a downstream consumer's
+code to break. E.g:
+
+* Any change that for a given API request results in different response bytes.
+  (This seems quite strict, but in the absence of any framework for classifying
+  breaking changes (_that would need to be communicated to and agreed upon by
+  downstream consumers_) we have to assume that any change in the bytes of a
+  response for a given request could break downstream consumers.)
+* Any changes in CLI flags or default values, except if a new flag has been
+  added which has no effect unless explicitly set.
+* Any changes to exported code in this repo or changes that would change the
+  value returned by code exported in this repo.
+* Bear in mind that breaking changes in the API of celo-blockchain can imply
+  breaking changes for this repo, for example changing the value returned by gas
+  estimation, or adding a field to a response. Also note that celo-blockchain
+  does not follow semantic versioning, so when updating it you will need to
+  investigate all changes included in an update and understand how they affect
+  rosetta to see if any are breaking.
+
+Changes that are not breaking and are not bug fixes are considered minor
+versions, there will likely be very few of these.
+
+Changes that are not breaking and are bug fixes are considered patch versions,
+it seems quite likely bug fixes could also be breaking.
+
+### Making a release
+
+* Ensure all required changes are merged to master.
+* Create a PR to update the `MiddlewareVersion` in `./service/rpc/versions.go`
+  set the version to the version of the release and merge to master.
+* Update the master branch on your local repo and run
+  `./scripts/set_tag_and_build_docker_images.sh` this will tag the current
+  commit with the `MiddlewareVersion` and build and push docker images for this
+  version and print out the tags of the docker images.
+* In github create a release for the aforementioned git tag, describe all
+  changes and breaking changes and add the tags for the docker images built by
+  the script.
+
+


### PR DESCRIPTION
Update readme with instructions on releasing

Also modified the release script to not create and push a release
commit.

Since the master branch is protected in this repo, it's not possible to
push a commit directly to master, that means that any commit made by the
script would be on a branch, and given that we may squash and merge
those branches we could end up not having the tags on master, even
though the state of master could be identical to the tagged commit on
the branch.

The instructions now ensure that we first merge all release changes to
master, and then tag that.
