### PR TITLE
Fix revokeMetadata bug

### DIFF
--- a/examples/airgap/main.go
+++ b/examples/airgap/main.go
@@ -18,8 +18,15 @@ import (
 	"context"
 	"log"
 
+	// "math/big"
+
 	"github.com/celo-org/celo-blockchain/common"
+	// "github.com/celo-org/celo-blockchain/common/hexutil"
+	// "github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/rosetta/airgap"
+
+	// celoClient "github.com/celo-org/kliento/client"
+	// "github.com/celo-org/kliento/registry"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 )
@@ -34,6 +41,7 @@ func main() {
 	}
 
 	// (or use an existing key)
+	// recommended for testing, since the account will need to have funds for gas fees
 	// privKeyBytes, err := hexutil.Decode("0x8e14643e23a3a6aa027e6e01fad86f54e63c5186636ce4be01ea9042907b1ff5")
 	// privKey, err := crypto.ToECDSA(privKeyBytes)
 
@@ -107,6 +115,7 @@ func main() {
 	}
 
 	// lockValue := big.NewInt(10000000000)
+
 	// txArgs, err = argBuilder.LockGold(*addr, lockValue)
 	// if err != nil {
 	// 	log.Fatalf("Error build txArgs: %s", err)
@@ -116,11 +125,40 @@ func main() {
 	// }
 
 	// cc, err := celoClient.Dial("http://localhost:8545")
-	// registry, err := wrapper.NewRegistry(cc)
-	// election, err := registry.GetElection(ctx, nil)
+	// registry, err := registry.New(cc)
+	// if err != nil {
+	// 	log.Fatalf("Error creating Registry: %s", err)
+	// }
+	// election, err := registry.GetElectionContract(ctx, nil)
+	// if err != nil {
+	// 	log.Fatalf("Error getting Election Contract: %s", err)
+	// }
 	// groups, err := election.GetEligibleValidatorGroups(nil)
+	// if err != nil {
+	// 	log.Fatalf("Error getting eligible validator groups: %s", err)
+	// }
 
 	// txArgs, err = argBuilder.Vote(*addr, groups[0], lockValue)
+	// if err != nil {
+	// 	log.Fatalf("Error build txArgs: %s", err)
+	// }
+	// if err = submitSigned(txArgs); err != nil {
+	// 	log.Fatalf("Error on submit Tx: %s", err)
+	// }
+
+	// votedForGroups, err := election.GetGroupsVotedForByAccount(nil, *addr)
+	// log.Printf("votedForGroups %s:", votedForGroups)
+
+	// // eligible
+	// txArgs, err = argBuilder.RevokePendingVotes(*addr, groups[0], lockValue)
+	// if err != nil {
+	// 	log.Fatalf("Error build txArgs: %s", err)
+	// }
+	// if err = submitSigned(txArgs); err != nil {
+	// 	log.Fatalf("Error on submit Tx: %s", err)
+	// }
+	// // not eligible
+	// txArgs, err = argBuilder.RevokePendingVotes(*addr, *addr, lockValue)
 	// if err != nil {
 	// 	log.Fatalf("Error build txArgs: %s", err)
 	// }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/celo-org/celo-bls-go-macos v0.6.4 // indirect
 	github.com/celo-org/celo-bls-go-other v0.6.4 // indirect
 	github.com/celo-org/celo-bls-go-windows v0.6.4 // indirect
-	github.com/celo-org/kliento v0.2.1-0.20221024130050-896466f9e8df
+	github.com/celo-org/kliento v0.2.1-0.20230302174154-e3fe27e18851
 	github.com/coinbase/rosetta-sdk-go v0.5.9
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/go-stack/stack v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/celo-org/celo-bls-go-other v0.6.4/go.mod h1:1xEWTbCXUrDx3Z6R9YlLi1zFN
 github.com/celo-org/celo-bls-go-windows v0.6.3/go.mod h1:8bRJbLcHREIAWn+5iZM3u8rGPBsWepp9BdF3SexisuM=
 github.com/celo-org/celo-bls-go-windows v0.6.4 h1:4w+NllEORQbsQnqpXO7UC+xDUbZQgiMPMnnyzLFA+ck=
 github.com/celo-org/celo-bls-go-windows v0.6.4/go.mod h1:8bRJbLcHREIAWn+5iZM3u8rGPBsWepp9BdF3SexisuM=
-github.com/celo-org/kliento v0.2.1-0.20221024130050-896466f9e8df h1:Th3X69EV3bYVtGDq+oJXV1LHi3vFSOGBDHe1n8K2fP8=
-github.com/celo-org/kliento v0.2.1-0.20221024130050-896466f9e8df/go.mod h1:E5olI06v1Ax1O6Ad8vKU4TYkWNxxki7CSpO2EHK79Qc=
 github.com/celo-org/kliento v0.2.1-0.20230302174154-e3fe27e18851 h1:y2BmZGeVTTnrBILY3YxMkfQ1CWA82Nxj7AxrYvvwLkg=
 github.com/celo-org/kliento v0.2.1-0.20230302174154-e3fe27e18851/go.mod h1:E5olI06v1Ax1O6Ad8vKU4TYkWNxxki7CSpO2EHK79Qc=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/celo-org/celo-bls-go-windows v0.6.4 h1:4w+NllEORQbsQnqpXO7UC+xDUbZQgi
 github.com/celo-org/celo-bls-go-windows v0.6.4/go.mod h1:8bRJbLcHREIAWn+5iZM3u8rGPBsWepp9BdF3SexisuM=
 github.com/celo-org/kliento v0.2.1-0.20221024130050-896466f9e8df h1:Th3X69EV3bYVtGDq+oJXV1LHi3vFSOGBDHe1n8K2fP8=
 github.com/celo-org/kliento v0.2.1-0.20221024130050-896466f9e8df/go.mod h1:E5olI06v1Ax1O6Ad8vKU4TYkWNxxki7CSpO2EHK79Qc=
+github.com/celo-org/kliento v0.2.1-0.20230302174154-e3fe27e18851 h1:y2BmZGeVTTnrBILY3YxMkfQ1CWA82Nxj7AxrYvvwLkg=
+github.com/celo-org/kliento v0.2.1-0.20230302174154-e3fe27e18851/go.mod h1:E5olI06v1Ax1O6Ad8vKU4TYkWNxxki7CSpO2EHK79Qc=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "1.0.0"
+	MiddlewareVersion = "1.0.1"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
### Description
- Updates kliento to include bugfix for nil pointer dereference in `revokeMetadata` when validator is ineligible (relevant kliento PR with details about the bug & fix: https://github.com/celo-org/kliento/pull/28)
- Updates airgap example script -- added back necessary imports, fixed outdated calls to instantiate registry & election contracts
  - Used for manually testing this bugfix & possibly useful for manual testing in the future
- Bumps version from 1.0.0 -> 1.0.1 in preparation for release

Closes https://github.com/celo-org/celo-blockchain-planning/issues/37

### Tested
- Manually tested
- Unit tests in election protocol tests to confirm assumptions
- Existing Rosetta unit tests pass
