### PR TITLE
Fix gas fee calculation to account for gasTipCap

### DIFF
--- a/analyzer/txtracer.go
+++ b/analyzer/txtracer.go
@@ -127,6 +127,7 @@ func (tr *Tracer) TxGasDetails(blockHeader *types.Header, tx *types.Transaction,
 	var feeHandler string
 
 	if tr.gingerbread {
+		// BaseFee is used directly because we only track balance changes from CELO gas fees
 		gpm = blockHeader.BaseFee
 		feeHandler = registry.FeeHandlerContractID.String()
 	} else {

--- a/analyzer/txtracer.go
+++ b/analyzer/txtracer.go
@@ -141,17 +141,17 @@ func (tr *Tracer) TxGasDetails(blockHeader *types.Header, tx *types.Transaction,
 
 	gasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 	baseTxFee := new(big.Int).Mul(gpm, gasUsed)
-	totalTip, err := tx.EffectiveGasTip(gpm)
+	effectiveTip, err := tx.EffectiveGasTip(gpm)
 	if err != nil {
 		return nil, fmt.Errorf("error computing EffectiveGasTip: %w", err)
 	}
 
 	// Convert tip to wei
-	totalTip.Mul(totalTip, gasUsed)
+	effectiveTip.Mul(effectiveTip, gasUsed)
 
-	runningTotalTxFee := new(big.Int).Set(totalTip)
+	runningTotalTxFee := new(big.Int).Set(effectiveTip)
 	// The "tip" goes to the coinbase address
-	balanceChanges.Add(blockHeader.Coinbase, totalTip)
+	balanceChanges.Add(blockHeader.Coinbase, effectiveTip)
 
 	// We want to get state AFTER the tx, since gas fees are processed by the end of the TX
 	feeHandlerAddress, err := tr.db.RegistryAddressStartOf(tr.ctx, receipt.BlockNumber, receipt.TransactionIndex+1, feeHandler)

--- a/analyzer/txtracer.go
+++ b/analyzer/txtracer.go
@@ -139,29 +139,32 @@ func (tr *Tracer) TxGasDetails(blockHeader *types.Header, tx *types.Transaction,
 	}
 
 	gasUsed := new(big.Int).SetUint64(receipt.GasUsed)
-
-	// baseTxFee is what goes to the community fund (if any)
 	baseTxFee := new(big.Int).Mul(gpm, gasUsed)
-	totalTxFee := new(big.Int).Mul(tx.GasPrice(), gasUsed)
+	totalTip, err := tx.EffectiveGasTip(gpm)
+	if err != nil {
+		return nil, fmt.Errorf("error computing EffectiveGasTip: %w", err)
+	}
 
+	// Convert tip to wei
+	totalTip.Mul(totalTip, gasUsed)
+
+	runningTotalTxFee := new(big.Int).Set(totalTip)
 	// The "tip" goes to the coinbase address
-	balanceChanges.Add(blockHeader.Coinbase, new(big.Int).Sub(totalTxFee, baseTxFee))
+	balanceChanges.Add(blockHeader.Coinbase, totalTip)
 
 	// We want to get state AFTER the tx, since gas fees are processed by the end of the TX
 	feeHandlerAddress, err := tr.db.RegistryAddressStartOf(tr.ctx, receipt.BlockNumber, receipt.TransactionIndex+1, feeHandler)
-	if err == db.ErrContractNotFound {
-		// No community fund, we won't charge the user
-		totalTxFee.Sub(totalTxFee, baseTxFee)
-	} else if err == nil {
-		// The baseTxFee goes to the community fund
+	if err == nil {
+		// User is charged baseFee iff community fund exists
 		balanceChanges.Add(feeHandlerAddress, baseTxFee)
-	} else {
+		runningTotalTxFee.Add(runningTotalTxFee, baseTxFee)
+	} else if err != db.ErrContractNotFound {
 		return nil, fmt.Errorf("can't get feeHandlerAddress: %w", err)
 	}
 
 	if tx.GatewayFeeRecipient() != nil {
 		balanceChanges.Add(*tx.GatewayFeeRecipient(), tx.GatewayFee())
-		totalTxFee.Add(totalTxFee, tx.GatewayFee())
+		runningTotalTxFee.Add(runningTotalTxFee, tx.GatewayFee())
 	}
 
 	// TODO find a better way to do this?
@@ -169,7 +172,7 @@ func (tr *Tracer) TxGasDetails(blockHeader *types.Header, tx *types.Transaction,
 	if err != nil {
 		return nil, fmt.Errorf("can't get transaction sender: %w", err)
 	}
-	balanceChanges.Add(from, new(big.Int).Neg(totalTxFee))
+	balanceChanges.Add(from, new(big.Int).Neg(runningTotalTxFee))
 	return NewFee(balanceChanges.ToMap()), nil
 }
 


### PR DESCRIPTION
### Description
Current gas calculation logic in Rosetta is incorrect for `DynamicFeeTx` and `CeloDynamicFeeTx` when `GasTipCap < GasFeeCap - BaseFee`. This PR fixes the logic by using `EffectiveGasTip` to directly compute the tip paid to the coinbase and sums this with the calculated `BaseFee` to get the correct total tx gas price.

Details:
- `GasPrice` is the tx fee limit
- Dynamic & CeloDynamic txs can also specify `GasTipCap`
- BaseFee calculation is the same for all of the txs (GPM)
- Tip calculation is different:
  - legacy: `GasPrice - BaseFee`
  - dynamic: `min(GasTipCap, GasFeeCap - BaseFee)`
    - `tx.EffectiveGasTip` should compute the tip properly for both legacy & new dynamic types since `GasTipCap==GasFeeCap==GasPrice` for legacy txs (so should be backwards compatible)

### Testing
- Fixes a reconciliation error seen with a `DynamicFeeTx` on the global testnet
- Passed reconciliation tests for at least the first 10k blocks on mainnet

Will run full reconciliation tests on this for the global testnet + ideally on baklava (as part of full G-fork release testing).