### PR TITLE
Release 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,7 @@ RUN go build --tags musl -o rosetta .
 # Outputs: rosetta & geth binaries on /usr/loca/bin
 #---------------------------------------------------------------------
 # geth mainnet
-# FROM us.gcr.io/celo-org/geth:1.6.1
-# TODO EN: for early testing
-FROM us.gcr.io/celo-org/geth:1.8.0-beta.2
+FROM us.gcr.io/celo-org/geth:1.8.0
 
 ARG COMMIT_SHA
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.15
 
 require (
 	github.com/allegro/bigcache v1.2.1 // indirect
-	// TODO EN: update once gingerbread release is available
-	github.com/celo-org/celo-blockchain v1.8.0-beta.2
+	github.com/celo-org/celo-blockchain v1.8.0
 	github.com/celo-org/celo-bls-go v0.6.4 // indirect
 	github.com/celo-org/celo-bls-go-android v0.6.4 // indirect
 	github.com/celo-org/celo-bls-go-ios v0.6.4 // indirect
@@ -13,9 +12,7 @@ require (
 	github.com/celo-org/celo-bls-go-macos v0.6.4 // indirect
 	github.com/celo-org/celo-bls-go-other v0.6.4 // indirect
 	github.com/celo-org/celo-bls-go-windows v0.6.4 // indirect
-	// TODO EN: update once kliento is fully updated
-	// points to head of eelanagaraj/gingerbread-updates
-	github.com/celo-org/kliento v0.2.1-0.20230823093212-b860f9f2351c
+	github.com/celo-org/kliento v0.2.1-0.20230912125702-70113468d45f
 	github.com/coinbase/rosetta-sdk-go v0.5.9
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/go-stack/stack v1.8.1 // indirect
@@ -29,6 +26,3 @@ require (
 	golang.org/x/net v0.7.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 )
-
-// TODO EN: undo once final kliento dep is published
-// replace github.com/celo-org/kliento => ../kliento

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
-github.com/celo-org/celo-blockchain v1.8.0-beta.2 h1:eX5PvqpJ47dg/A6UzpDVBN99P2XAXUOuYh66umUGiqo=
-github.com/celo-org/celo-blockchain v1.8.0-beta.2/go.mod h1:Xwrl4Up8aP/p6TolAiHSTVSlsGtu1N6JZADaJaENYYY=
+github.com/celo-org/celo-blockchain v1.8.0 h1:LJ+BQG1v9Wmy9TsLb/LchPhpFKz8c4rDCEz6iZf6y1M=
+github.com/celo-org/celo-blockchain v1.8.0/go.mod h1:Xwrl4Up8aP/p6TolAiHSTVSlsGtu1N6JZADaJaENYYY=
 github.com/celo-org/celo-bls-go v0.3.4/go.mod h1:qDZHMC3bBqOw5qle28cRtKlEyJhslZtckcc2Tomqdks=
 github.com/celo-org/celo-bls-go v0.6.4 h1:zBf6pEr9k64gaO0VSYnDfLCBmrxDigc4yUaDvWub5G8=
 github.com/celo-org/celo-bls-go v0.6.4/go.mod h1:apSlSDPoXIdGseCS4Z2AMrhO5B1xpIVTXYpfv/uRd04=
@@ -129,8 +129,8 @@ github.com/celo-org/celo-bls-go-windows v0.3.3/go.mod h1:82GC5iJA9Qw5gynhYqR8ht3
 github.com/celo-org/celo-bls-go-windows v0.6.3/go.mod h1:8bRJbLcHREIAWn+5iZM3u8rGPBsWepp9BdF3SexisuM=
 github.com/celo-org/celo-bls-go-windows v0.6.4 h1:4w+NllEORQbsQnqpXO7UC+xDUbZQgiMPMnnyzLFA+ck=
 github.com/celo-org/celo-bls-go-windows v0.6.4/go.mod h1:8bRJbLcHREIAWn+5iZM3u8rGPBsWepp9BdF3SexisuM=
-github.com/celo-org/kliento v0.2.1-0.20230823093212-b860f9f2351c h1:7Mhu9yX5Dn+L5KyDI3gYYsX7b3w23x7Qlzp9rLDAeik=
-github.com/celo-org/kliento v0.2.1-0.20230823093212-b860f9f2351c/go.mod h1:BFFgdANZPxh0o9F8VaeO+v/r1z2t/YST7eldplj1DbY=
+github.com/celo-org/kliento v0.2.1-0.20230912125702-70113468d45f h1:ITkZ/94WqeMio54DYQzfcFDZBkUAogncZyKXXu0FWkk=
+github.com/celo-org/kliento v0.2.1-0.20230912125702-70113468d45f/go.mod h1:jp7HC2Sh7VUuGzmVUrX/4/TUz8MEPI2Qb6q6esIZhN0=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
# Description
- Bumps celo-blockchain dep to 1.8.0 (stable)
- Bumps kliento dep to `70113468d45f1a09bb1d3944d0c34c9d2f3135a0` (latest commit on master, which contains 1.8.0 blockchain update and contracts generated from the same monorepo commit as on celo-blockchain 1.8.0)
- Updates Rosetta dockerfile to use `us.gcr.io/celo-org/geth:1.8.0` image
- Bump rosetta service version (`MiddlewareVersion`) to 2.0.0 in preparation for release

Release notes drafted [here](https://github.com/celo-org/rosetta/releases/tag/untagged-0e9882f0f6c5e472a796); will tag the final release after doing sanity checks on the docker image. (Already did sanity checks on docker image built from [a7e37ad](https://github.com/celo-org/rosetta/pull/210/commits/a7e37ad491a8216719b64f3be5e23a2bfbe57b25), which should be exactly the same as the merged version of this PR.)