### PR TITLE
Bump middleware version to 2.0.0

### DIFF
--- a/service/rpc/versions.go
+++ b/service/rpc/versions.go
@@ -24,6 +24,6 @@ const (
 )
 
 var (
-	MiddlewareVersion = "2.0.0-dev"
+	MiddlewareVersion = "2.0.0"
 	NodeVersion       = params.Version
 )


### PR DESCRIPTION
Include commit missed in https://github.com/celo-org/rosetta/pull/210