### PR TITLE
Improve debugging and CLI test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,11 @@ rosetta-cli check:data --configuration-file $PATH_TO_ROSETTA/rosetta-cli-conf/$N
 
 ### How to generate `bootstrap_balances.json`
 
-This is only necessary for running the data checks if it has not already been created for the particular network. Here's how to generate this for alfajores (for another network, specify the appropriate genesis block URL and output path):
+This is only necessary for running the data checks if it has not already been created for the particular network. Here's how to generate this for alfajores (for another network, specify the appropriate genesis block filepath and output path):
 
 ```sh
 go run examples/generate_balances/main.go \
-  https://storage.googleapis.com/genesis_blocks/alfajores \
-  rosetta-cli-conf/testnet/bootstrap_balances.json
+  $PATH_TO_GENESIS_FILE rosetta-cli-conf/mycelo/bootstrap_balances.json
 ```
 
 ### Running Rosetta with a mycelo testnet

--- a/README.md
+++ b/README.md
@@ -189,15 +189,16 @@ needs to reach the tip before submitting transactions. The data checks will
 take a while to complete as well (likely a couple of days on a normal laptop
 with the current settings) as they reconcile balances for the entire chain._
 
-- Install the [`rosetta-cli`](https://github.com/coinbase/rosetta-cli) according to the instructions. (Note that on Mac, installing the `rosetta-cli` to `/usr/local/bin` or adding its location to you `$PATH` will allow you to call `rosetta-cli` directly on the command line rather than needing to provide the path to the executable). Current testing has been done with `v0.5.16` of the `rosetta-cli`.
-- Run the Rosetta service in the background for the respective network (currently only alfajores for both Data and Construction checks)
-- Run the CLI checks for alfajores as follows:
+- Install the [`rosetta-cli`](https://github.com/coinbase/rosetta-cli) according to the instructions. (Note that on Mac, installing the `rosetta-cli` to `/usr/local/bin` or adding its location to you `$PATH` will allow you to call `rosetta-cli` directly on the command line rather than needing to provide the path to the executable). Current testing has been done with `v0.10.3` of the `rosetta-cli`.
+- Run the Rosetta service in the background for the respective network (currently only alfajores for both data and construction checks, the data checks work for all other networks).
+- Run the CLI checks for `NETWORK_NAME` as follows:
 
 ```sh
 # alfajores; specify construction or data
-rosetta-cli check:construction --configuration-file PATH/TO/rosetta/rosetta-cli-conf/testnet/cli-config.json
+rosetta-cli check:data --configuration-file $PATH_TO_ROSETTA/rosetta-cli-conf/$NETWORK_NAME/cli-config.json
 ```
 
+[See below](#running-rosetta-with-a-mycelo-testnet) for more details on running the reconciliation checks against a mycelo testnet.
 
 ### How to generate `bootstrap_balances.json`
 
@@ -215,11 +216,11 @@ go run examples/generate_balances/main.go \
 - Set `--geth.networkid` to the network ID (if this is a deployed testnet, this may be different from the `ChainID` in the genesis file). If this value is the same as the `ChainID`, it is not necessary to set this parameter.
 - Set the `--monitor.initcontracts` flag (at least on the first run), which fetches necessary state from the genesis block and updates the Rosetta DB accordingly.
 
-To run reconciliation tests on this network:
+To run reconciliation tests on this network, you can use the `cli-config` in `./rosetta-cli-conf/mycelo` as a basis. (Note: the default `cli-config` uses the chain ID that is set when the `loadtest` template is used to set up the mycelo network).
 
-- Generate `bootstrap_balances.json` using the network's genesis block.
+- [Generate `bootstrap_balances.json`](#how-to-generate-bootstrap_balancesjson) within the same folder, using the mycelo network's genesis block.
 - In the `cli-config.json`:
-  - Set `network` to match the `ChainID` in the genesis file (not the network ID).
+  - Set `network` parameter to match the `ChainID` in the genesis file (not the network ID).
   - Point `bootstrap_balances` to the generated `bootstrap_balances.json`.
 
 #### Example

--- a/examples/generate_balances/main.go
+++ b/examples/generate_balances/main.go
@@ -17,9 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/celo-org/celo-blockchain/core"
@@ -34,26 +32,20 @@ type BootstrapBalance struct {
 
 func main() {
 	if len(os.Args) != 3 {
-		fmt.Println("Usage: generate_balances <genesisURL> <outputFile>")
+		fmt.Println("Usage: generate_balances <pathToGenesis> <outputFile>")
 		os.Exit(1)
 	}
-	genesisURL := os.Args[1]
+	genesisPath := os.Args[1]
 	bootstrapBalancesFile := os.Args[2]
-	// Get Genesis File
-	resp, err := http.Get(genesisURL)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	data, err := os.ReadFile(genesisPath)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	genesis := &core.Genesis{}
-	if err := json.Unmarshal(body, genesis); err != nil {
+	if err := json.Unmarshal(data, genesis); err != nil {
 		log.Fatalln(err)
 	}
-	log.Printf("%+v\n", genesis.Alloc)
+	log.Println("Loaded genesis file, writing allocation file")
 	// Write to file
 	balances := []*BootstrapBalance{}
 	for k, v := range genesis.Alloc {
@@ -76,7 +68,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := ioutil.WriteFile(bootstrapBalancesFile, file, os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(bootstrapBalancesFile, file, os.FileMode(0600)); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Bootstrap file contains %d balances\n", len(balances))

--- a/rosetta-cli-conf/baklava/cli-config.json
+++ b/rosetta-cli-conf/baklava/cli-config.json
@@ -37,7 +37,9 @@
     "inactive_discrepancy_search_disabled": false,
     "end_conditions": {
       "reconciliation_coverage": {
-        "coverage": 0.95
+        "coverage": 0.95,
+        "from_tip": true,
+        "tip": true
       }
     }
   }

--- a/rosetta-cli-conf/mainnet/cli-config.json
+++ b/rosetta-cli-conf/mainnet/cli-config.json
@@ -1,44 +1,46 @@
 {
-    "network": {
-      "blockchain": "celo",
-      "network": "42220"
-    },
-    "online_url": "http://localhost:8080",
-    "data_directory": "",
-    "http_timeout": 300,
-    "max_retries": 5,
-    "retry_elapsed_time": 0,
-    "max_online_connections": 120,
-    "max_sync_concurrency": 1,
-    "tip_delay": 300,
-    "log_configuration": false,
-    "compression_disabled": false,
-    "construction": null,
-    "data": {
-      "active_reconciliation_concurrency": 16,
-      "inactive_reconciliation_concurrency": 4,
-      "inactive_reconciliation_frequency": 250,
-      "log_blocks": false,
-      "log_transactions": false,
-      "log_balance_changes": false,
-      "log_reconciliations": false,
-      "ignore_reconciliation_error": false,
-      "exempt_accounts": "",
-      "bootstrap_balances": "bootstrap_balances.json",
-      "interesting_accounts": "",
-      "reconciliation_disabled": false,
-      "reconciliation_drain_disabled": false,
-      "inactive_discrepency_search_disabled": false,
-      "balance_tracking_disabled": false,
-      "coin_tracking_disabled": false,
-      "status_port": 9090,
-      "results_output_file": "",
-      "initial_balance_fetch_disabled": false,
-      "historical_balance_disabled": false,
-      "end_conditions": {
-        "reconciliation_coverage": {
-          "coverage": 0.95
-        }
+  "network": {
+    "blockchain": "celo",
+    "network": "42220"
+  },
+  "online_url": "http://localhost:8080",
+  "data_directory": "",
+  "http_timeout": 300,
+  "max_retries": 5,
+  "retry_elapsed_time": 0,
+  "max_online_connections": 120,
+  "max_sync_concurrency": 1,
+  "tip_delay": 300,
+  "log_configuration": false,
+  "compression_disabled": false,
+  "construction": null,
+  "data": {
+    "active_reconciliation_concurrency": 16,
+    "inactive_reconciliation_concurrency": 4,
+    "inactive_reconciliation_frequency": 250,
+    "log_blocks": false,
+    "log_transactions": false,
+    "log_balance_changes": false,
+    "log_reconciliations": false,
+    "ignore_reconciliation_error": false,
+    "exempt_accounts": "",
+    "bootstrap_balances": "bootstrap_balances.json",
+    "interesting_accounts": "",
+    "reconciliation_disabled": false,
+    "reconciliation_drain_disabled": false,
+    "inactive_discrepency_search_disabled": false,
+    "balance_tracking_disabled": false,
+    "coin_tracking_disabled": false,
+    "status_port": 9090,
+    "results_output_file": "",
+    "initial_balance_fetch_disabled": false,
+    "historical_balance_disabled": false,
+    "end_conditions": {
+      "reconciliation_coverage": {
+        "coverage": 0.95,
+        "from_tip": true,
+        "tip": true
       }
     }
   }
+}

--- a/rosetta-cli-conf/mycelo/cli-config.json
+++ b/rosetta-cli-conf/mycelo/cli-config.json
@@ -1,7 +1,7 @@
 {
   "network": {
     "blockchain": "celo",
-    "network": "44787"
+    "network": "9099000"
   },
   "online_url": "http://localhost:8080",
   "data_directory": "",
@@ -13,37 +13,7 @@
   "tip_delay": 300,
   "log_configuration": false,
   "compression_disabled": false,
-  "construction": {
-    "offline_url": "http://localhost:8080",
-    "max_offline_connections": 4,
-    "stale_depth": 30,
-    "broadcast_limit": 3,
-    "ignore_broadcast_failures": false,
-    "clear_broadcasts": false,
-    "broadcast_behind_tip": false,
-    "block_broadcast_limit": 5,
-    "rebroadcast_all": false,
-    "prefunded_accounts": [
-      {
-        "privkey": "b803642b3a58699b8442546ccbd5d5c0d5dba97b2b5b868a263fd0f4c0fd7bc5",
-        "account_identifier": {
-          "address": "0x03dDDE31C7d3Bd9C6d190185E04A340981586427"
-        },
-        "curve_type": "secp256k1",
-        "currency": {
-          "symbol": "cGLD",
-          "decimals": 18
-        }
-      }
-    ],
-    "constructor_dsl_file": "celo.ros",
-    "status_port": 9090,
-    "initial_balance_fetch_disabled": false,
-    "end_conditions": {
-      "create_account": 10,
-      "transfer": 10
-    }
-  },
+  "construction": null,
   "data": {
     "active_reconciliation_concurrency": 16,
     "inactive_reconciliation_concurrency": 4,
@@ -53,7 +23,6 @@
     "log_balance_changes": false,
     "log_reconciliations": false,
     "ignore_reconciliation_error": false,
-    "exempt_accounts": "",
     "bootstrap_balances": "bootstrap_balances.json",
     "interesting_accounts": "",
     "reconciliation_disabled": false,

--- a/scripts/reconciliation_debugging.py
+++ b/scripts/reconciliation_debugging.py
@@ -1,0 +1,188 @@
+# Simple scripts for investigating reconciliation failures.
+# Usage help: python3 scripts/reconciliation_debugging.py --help
+
+import requests
+import argparse
+
+
+def wrap_response(response):
+    if response.status_code != 200:
+        raise ValueError("Request failed: ", response.text)
+    return response.json()
+
+
+def network_req_from_chain_id(chain_id):
+    return {"blockchain": "celo", "network": f"{chain_id}"}
+
+
+def request_account_balance(node_url, network_id, address, block_number):
+    return wrap_response(
+        requests.post(
+            f"{node_url}/account/balance",
+            json={
+                "network_identifier": network_id,
+                "account_identifier": {
+                    "address": address,
+                },
+                "block_identifier": {"index": block_number},
+            },
+        )
+    )
+
+
+def request_block(node_url, network_id, block_number):
+    """
+    Query blockscout API for block_tx
+    """
+    req_json = {
+        "network_identifier": network_id,
+        "block_identifier": {"index": block_number},
+    }
+    return wrap_response(requests.post(f"{node_url}/block", json=req_json))
+
+
+def request_block_tx(node_url, network_id, address, block_number, block_hash, tx_hash):
+    return wrap_response(
+        requests.post(
+            f"{node_url}/block/transaction",
+            json={
+                "network_identifier": network_id,
+                "account_identifier": {
+                    "address": address,
+                },
+                "block_identifier": {"index": block_number, "hash": block_hash},
+                "transaction_identifier": {"hash": tx_hash},
+            },
+        )
+    )
+
+
+def account_balance(
+    block_number,
+    node_url,
+    reconcile_address,
+    network_id,
+):
+    # get account/balance balance
+    resp = request_account_balance(
+        node_url, network_id, reconcile_address, block_number
+    )
+
+    balances = resp["balances"]
+
+    # if not, let's investigate this
+    assert len(balances) == 1
+    return int(balances[0]["value"])
+
+
+def block_tx_balance_change(
+    block_number,
+    block_hash,
+    tx_hash,
+    node_url,
+    reconcile_address,
+    network_id,
+):
+    resp = request_block_tx(
+        node_url,
+        network_id,
+        reconcile_address,
+        block_number,
+        block_hash,
+        tx_hash,
+    )
+    try:
+        ops = resp["transaction"].get("operations", [])  # or []
+        return sum(
+            [
+                int(op["amount"]["value"])
+                for op in ops
+                if op["account"]["address"] == reconcile_address
+                and op["status"] == "success"
+            ]
+        )
+
+    except Exception as e:
+        print(f"Exception for response: {resp}")
+        raise e
+
+
+# Useful when trying to shrink the range to search over and reconcile,
+# i.e. when it's not yet known when exactly the reconciliation error occurs.
+def scan_account_balance_changes(
+    start_block,
+    end_block,
+    step,
+    node_url,
+    reconcile_address,
+    network_id,
+):
+    balance = None
+    balance_changes = []
+    for block_number in range(start_block, end_block, step):
+        curr_balance = account_balance(
+            block_number, node_url, reconcile_address, network_id
+        )
+        if balance != curr_balance:
+            print(f"balance change at: {block_number}, curr_balance: {curr_balance}")
+            balance_changes.append(balance)
+        balance = curr_balance
+    return balance_changes
+
+
+# Performs targetted balance reconciliation (same idea as Rosetta CLI checks)
+# over a restricted range and for a particular address.
+def reconcile_range(
+    start_block,
+    end_block,
+    node_url,
+    reconcile_address,
+    network_id,
+):
+    assert start_block > 0
+    curr_balance = account_balance(
+        start_block - 1, node_url, reconcile_address, network_id
+    )
+    print(f"starting balance: {curr_balance}")
+
+    for i in range(start_block, end_block):
+        print(f"beginning block {i}")
+        # fetch account_balance changes
+        new_balance = account_balance(i, node_url, reconcile_address, network_id)
+        block = request_block(node_url, network_id, i)
+        block_hash = block["block"]["block_identifier"]["hash"]
+
+        sum_ops_change = sum(
+            [
+                block_tx_balance_change(
+                    i,
+                    block_hash,
+                    tx["hash"],
+                    node_url,
+                    reconcile_address,
+                    network_id,
+                )
+                for tx in block.get("other_transactions", [])
+            ]
+        )
+        assert (
+            curr_balance + sum_ops_change == new_balance
+        ), f"failure for block {i}, curr_balance: {curr_balance}, new_balance: {new_balance}, sum_ops_change: {sum_ops_change}"
+        curr_balance = new_balance
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("start", type=int, help="starting block in range")
+    parser.add_argument("end", type=int, help="ending block in range")
+    parser.add_argument("chain_id", type=int, help="chain ID in genesis.json")
+    parser.add_argument(
+        "address", type=str, help="address whose balance to reconcile over range"
+    )
+    parser.add_argument(
+        "-n", "--node_url", default="http://localhost:8080", help="rosetta RPC URL"
+    )
+    args = parser.parse_args()
+    network_req = network_req_from_chain_id(args.chain_id)
+
+    reconcile_range(args.start, args.end, args.node_url, args.address, network_req)


### PR DESCRIPTION
### Description
- Fixes CLI configs for all testnets (and adds one for default loadtest env. mycelo networks)
- Updates README
- Adds a Python script for manually investigating reconciliation errors (by reconciling small ranges), useful for debugging

### Tested
manually, adds testing scripts. No changes to actual service.