### PR TITLE
Enable arbitrary contract calls on /construction/metadata

### DIFF
--- a/airgap/api.go
+++ b/airgap/api.go
@@ -96,6 +96,10 @@ type TxArgs struct {
 	// non-nil means celo registry contract invokation
 	Method *CeloMethod
 	Args   []interface{}
+	// ArgsEncoded is set to true for arbitrary contract calls where
+	// the args array has one element containing the pre-encoded args data,
+	// as a hex encoded string
+	ArgsEncoded *bool
 }
 
 type CallParams struct {

--- a/airgap/api.go
+++ b/airgap/api.go
@@ -99,7 +99,7 @@ type TxArgs struct {
 	// ArgsEncoded is set to true for arbitrary contract calls where
 	// the args array has one element containing the pre-encoded args data,
 	// as a hex encoded string
-	ArgsEncoded *bool
+	ArgsEncoded bool
 }
 
 type CallParams struct {

--- a/airgap/method_registry.go
+++ b/airgap/method_registry.go
@@ -26,7 +26,12 @@ var methodRegistry = make(map[string]map[string]*CeloMethod)
 func MethodFromString(celoMethodStr string) (*CeloMethod, error) {
 	parts := strings.Split(celoMethodStr, ".")
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("Invalid method string: %s", celoMethodStr)
+		// If there is no . present, try to parse this string as a generic EVM method signature
+		unregisteredMethod, err := unregisteredMethodFromString(celoMethodStr)
+		if err != nil {
+			return nil, err
+		}
+		return unregisteredMethod, nil
 	}
 	m, ok := methodRegistry[parts[0]]
 	if !ok {
@@ -51,4 +56,53 @@ func registerMethod(contract string, name string, argParsers []argParser) *CeloM
 	}
 	methodRegistry[contract][name] = cm
 	return cm
+}
+
+// unregisteredMethodFromString returns a CeloMethod representing an arbitrary EVM-compatible method
+// Unknown methods are represented by their function signature string like "transfer(bytes32,address)"
+func unregisteredMethodFromString(methodSignature string) (*CeloMethod, error) {
+	if err := validateMethodSignature(methodSignature); err != nil {
+		return nil, err
+	}
+	unregisteredMethod := CeloMethod{
+		Name: methodSignature,
+		// Unregistered methods do not identify contract by name
+		// The "to" address value should be set to the contract's address
+		Contract: "",
+		// Unregistered methods do not use argParsers
+		// Args will be pre-encoded OR parsed based on the methodSignature
+		argParsers: nil,
+	}
+	return &unregisteredMethod, nil
+}
+
+func validateMethodSignature(methodSig string) error {
+	splitSigByLeadingParenthesis := strings.Split(methodSig, "(")
+	if len(splitSigByLeadingParenthesis) < 2 {
+		return nil
+	}
+	splitSigByTrailingParenthesis := strings.Split(splitSigByLeadingParenthesis[1], ")")
+	if len(splitSigByTrailingParenthesis) < 1 || splitSigByTrailingParenthesis[0] == "" {
+		return nil
+	}
+	methodTypes := strings.Split(splitSigByTrailingParenthesis[0], ",")
+
+	for _, v := range methodTypes {
+		switch {
+		case v == "address":
+			continue
+		case strings.HasPrefix(v, "uint") || strings.HasPrefix(v, "int"):
+			continue
+		case strings.HasPrefix(v, "bytes"):
+			continue
+		case v == "string":
+			continue
+		case v == "bool":
+			continue
+		default:
+			return fmt.Errorf("Invalid type %s in method signature: %s", v, methodSig)
+		}
+	}
+
+	return nil
 }

--- a/airgap/method_registry.go
+++ b/airgap/method_registry.go
@@ -77,17 +77,27 @@ func unregisteredMethodFromString(methodSignature string) (*CeloMethod, error) {
 }
 
 func validateMethodSignature(methodSig string) error {
-	splitSigByLeadingParenthesis := strings.Split(methodSig, "(")
-	if len(splitSigByLeadingParenthesis) < 2 {
-		return nil
+	// Check if the method signature contains both opening and closing parentheses
+	openParenIndex := strings.Index(methodSig, "(")
+	closeParenIndex := strings.Index(methodSig, ")")
+	if openParenIndex == -1 || closeParenIndex == -1 || openParenIndex > closeParenIndex {
+		return fmt.Errorf("Invalid method signature: %s", methodSig)
 	}
-	splitSigByTrailingParenthesis := strings.Split(splitSigByLeadingParenthesis[1], ")")
-	if len(splitSigByTrailingParenthesis) < 1 || splitSigByTrailingParenthesis[0] == "" {
-		return nil
-	}
-	methodTypes := strings.Split(splitSigByTrailingParenthesis[0], ",")
 
+	// Extract the contents inside the parentheses
+	paramString := methodSig[openParenIndex+1 : closeParenIndex]
+
+	// If there are no contents, the signature is valid
+	if paramString == "" {
+		return nil
+	}
+
+	// Split the contents by comma to get individual type strings
+	methodTypes := strings.Split(paramString, ",")
+
+	// Iterate through each type string and validate
 	for _, v := range methodTypes {
+		v = strings.TrimSpace(v) // Trim any leading/trailing whitespace
 		switch {
 		case v == "address":
 			continue

--- a/airgap/method_registry_test.go
+++ b/airgap/method_registry_test.go
@@ -1,0 +1,25 @@
+package airgap
+
+import "testing"
+
+func Test_validateMethodSignature(t *testing.T) {
+	tests := []struct {
+		name      string
+		methodSig string
+		wantErr   bool
+	}{
+		{name: "valid signature with no args", methodSig: "noArgs()", wantErr: false},
+		{name: "valid signature with one arg", methodSig: "deploy(address)", wantErr: false},
+		{name: "valid signature with multiple args", methodSig: "deploy(address,uint8,bytes16,address)", wantErr: false},
+		{name: "signature with invalid arg type", methodSig: "batchTransfer(DepositWalletTransfer[])", wantErr: true},
+		{name: "closing parenthesis only", methodSig: "noArgs)", wantErr: true},
+		{name: "open parenthesis only", methodSig: "noArgs(", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateMethodSignature(tt.methodSig); (err != nil) != tt.wantErr {
+				t.Errorf("validateMethodSignature() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/airgap/method_registry_test.go
+++ b/airgap/method_registry_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package airgap
 
 import "testing"

--- a/airgap/methods.go
+++ b/airgap/methods.go
@@ -96,7 +96,12 @@ type CeloMethod struct {
 	argParsers []argParser
 }
 
-func (cm *CeloMethod) String() string { return fmt.Sprintf("%s.%s", cm.Contract, cm.Name) }
+func (cm *CeloMethod) String() string {
+	if cm.Contract == "" {
+		return cm.Name
+	}
+	return fmt.Sprintf("%s.%s", cm.Contract, cm.Name)
+}
 
 func (cm *CeloMethod) SerializeArguments(args ...interface{}) ([]interface{}, error) {
 	if len(args) != len(cm.argParsers) {

--- a/airgap/server/e2e_test.go
+++ b/airgap/server/e2e_test.go
@@ -196,6 +196,6 @@ func buildContractCallTxArgs(from common.Address, value int64, to common.Address
 		To:          &to,
 		Method:      &airgap.CeloMethod{Name: methodSig},
 		Args:        args,
-		ArgsEncoded: &argsEncoded,
+		ArgsEncoded: argsEncoded,
 	}
 }

--- a/airgap/server/methods.go
+++ b/airgap/server/methods.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"golang.org/x/crypto/sha3"
 	"log"
 	"math/big"
 	"strconv"
@@ -30,6 +29,7 @@ import (
 	"github.com/celo-org/kliento/contracts"
 	"github.com/celo-org/kliento/registry"
 	"github.com/celo-org/rosetta/airgap"
+	"golang.org/x/crypto/sha3"
 )
 
 var abiFactoryMap = map[string]func() (*abi.ABI, error){

--- a/airgap/server/methods.go
+++ b/airgap/server/methods.go
@@ -16,9 +16,17 @@ package server
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"golang.org/x/crypto/sha3"
+	"log"
+	"math/big"
+	"strconv"
+	"strings"
 
 	"github.com/celo-org/celo-blockchain/accounts/abi"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/kliento/contracts"
 	"github.com/celo-org/kliento/registry"
 	"github.com/celo-org/rosetta/airgap"
@@ -131,4 +139,172 @@ func airgapMethodFactory(srvCtx ServerContext, abi *abi.ABI, argsParser argsPreP
 
 		return data, nil
 	}
+}
+
+// constructContractCallDataGeneric constructs the data field of a transaction.
+// The methodArgs can be already in ABI encoded format in case of a single string
+// It can also be passed in as a slice of args, which requires further encoding.
+func constructContractCallDataGeneric(methodSig string, methodArgs interface{}) ([]byte, error) {
+	data, err := contractCallMethodID(methodSig)
+	if err != nil {
+		return nil, err
+	}
+
+	// switch on the type of the method args. method args can come in from json as either a string or list of strings
+	switch methodArgs := methodArgs.(type) {
+	// case 0: no method arguments, return the selector
+	case nil:
+		return data, nil
+
+	// case 1: method args are pre-compiled ABI data. decode the hex and create the call data directly
+	case string:
+		methodArgs = strings.TrimPrefix(methodArgs, "0x")
+		b, decErr := hex.DecodeString(methodArgs)
+		if decErr != nil {
+			return nil, fmt.Errorf("error decoding method args hex data: %w", decErr)
+		}
+		return append(data, b...), nil
+
+	// case 2: method args are a list of interface{} which will be converted to string before encoding
+	case []interface{}:
+		var strList []string
+		for i, genericVal := range methodArgs {
+			strVal, isStrVal := genericVal.(string)
+			if !isStrVal {
+				return nil, fmt.Errorf("invalid method_args type at index %d: %T (must be a string)",
+					i, genericVal,
+				)
+			}
+			strList = append(strList, strVal)
+		}
+		return encodeMethodArgsStrings(data, methodSig, strList)
+
+	// case 3: method args are encoded as a list of strings, which will be decoded
+	case []string:
+		return encodeMethodArgsStrings(data, methodSig, methodArgs)
+
+	// case 4: there is no known way to decode the method args
+	default:
+		return nil, fmt.Errorf(
+			"invalid method_args type, accepted values are []string and hex-encoded string."+
+				" type received=%T value=%#v", methodArgs, methodArgs,
+		)
+	}
+}
+
+// Sourced from: https://github.com/coinbase/rosetta-geth-sdk/blob/master/services/construction/contract_call_data.go
+// TODO: install from rosetta-geth-sdk directly when update is possible
+//
+// encodeMethodArgsStrings constructs the data field of a transaction for a list of string args.
+// It attempts to first convert the string arg to it's corresponding type in the method signature,
+// and then performs abi encoding to the converted args list and construct the data.
+func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []string) ([]byte, error) {
+	arguments := abi.Arguments{}
+	var argumentsData []interface{}
+
+	var data []byte
+	data = append(data, methodID...)
+
+	const split = 2
+	splitSigByLeadingParenthesis := strings.Split(methodSig, "(")
+	if len(splitSigByLeadingParenthesis) < split {
+		return data, nil
+	}
+	splitSigByTrailingParenthesis := strings.Split(splitSigByLeadingParenthesis[1], ")")
+	if len(splitSigByTrailingParenthesis) < 1 || splitSigByTrailingParenthesis[0] == "" {
+		return data, nil
+	}
+	splitSigByComma := strings.Split(splitSigByTrailingParenthesis[0], ",")
+
+	if len(splitSigByComma) != len(methodArgs) {
+		return nil, fmt.Errorf("invalid method arguments")
+	}
+
+	for i, v := range splitSigByComma {
+		typed, _ := abi.NewType(v, v, nil)
+		argument := abi.Arguments{
+			abi.Argument{
+				Type: typed,
+			},
+		}
+
+		arguments = append(arguments, argument...)
+		var argData interface{}
+		const base = 10
+		switch {
+		case v == "address":
+			{
+				argData = common.HexToAddress(methodArgs[i])
+			}
+		case v == "uint32":
+			{
+				u64, err := strconv.ParseUint(methodArgs[i], 10, 32)
+				if err != nil {
+					log.Fatal(err)
+				}
+				argData = uint32(u64)
+			}
+		case strings.HasPrefix(v, "uint") || strings.HasPrefix(v, "int"):
+			{
+				value := new(big.Int)
+				value.SetString(methodArgs[i], base)
+				argData = value
+			}
+		case v == "bytes32":
+			{
+				value := [32]byte{}
+				bytes, err := hexutil.Decode(methodArgs[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				copy(value[:], bytes)
+				argData = value
+			}
+		case strings.HasPrefix(v, "bytes"):
+			{
+				// No fixed size set as it would make it an "array" instead
+				// of a "slice" when encoding. We want it to be a slice.
+				value := []byte{}
+				bytes, err := hexutil.Decode(methodArgs[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				copy(value[:], bytes) // nolint:gocritic
+				argData = value
+			}
+		case strings.HasPrefix(v, "string"):
+			{
+				argData = methodArgs[i]
+			}
+		case strings.HasPrefix(v, "bool"):
+			{
+				value, err := strconv.ParseBool(methodArgs[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				argData = value
+			}
+		}
+		argumentsData = append(argumentsData, argData)
+	}
+
+	abiEncodeData, err := arguments.PackValues(argumentsData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode arguments: %w", err)
+	}
+
+	data = append(data, abiEncodeData...)
+	return data, nil
+}
+
+// contractCallMethodID calculates the first 4 bytes of the method
+// signature for function call on contract
+func contractCallMethodID(methodSig string) ([]byte, error) {
+	fnSignature := []byte(methodSig)
+	hash := sha3.NewLegacyKeccak256()
+	if _, err := hash.Write(fnSignature); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(nil)[:4], nil
 }

--- a/airgap/server/server.go
+++ b/airgap/server/server.go
@@ -170,7 +170,7 @@ func (b *airGapServerImpl) ObtainMetadata(ctx context.Context, options *airgap.T
 			log.Printf("Building metadata for contract call method %s", methodSig)
 
 			var methodArgs interface{}
-			if options.ArgsEncoded != nil && *options.ArgsEncoded {
+			if options.ArgsEncoded {
 				// options.Args is a string array and the first element is the encoded args
 				if len(options.Args) > 0 {
 					if encodedArgsData, ok := options.Args[0].(string); ok {

--- a/airgap/txargs_marshall.go
+++ b/airgap/txargs_marshall.go
@@ -21,11 +21,12 @@ import (
 )
 
 type txArgsRawData struct {
-	From   common.Address  `json:"from"`
-	Value  *string         `json:"value,omitempty"`
-	To     *common.Address `json:"to,omitempty"`
-	Method *string         `json:"method,omitempty"`
-	Args   []interface{}   `json:"args,omitempty"`
+	From        common.Address  `json:"from"`
+	Value       *string         `json:"value,omitempty"`
+	To          *common.Address `json:"to,omitempty"`
+	Method      *string         `json:"method,omitempty"`
+	Args        []interface{}   `json:"args,omitempty"`
+	ArgsEncoded *bool           `json:"args_encoded,omitempty"`
 }
 
 type callParamsRawData struct {
@@ -46,6 +47,7 @@ func (data *txArgsRawData) transform(args *TxArgs) error {
 		return err
 	}
 	args.Args = data.Args
+	args.ArgsEncoded = data.ArgsEncoded
 	return nil
 }
 
@@ -59,6 +61,7 @@ func (args *TxArgs) transform() *txArgsRawData {
 		data.Method = &str
 	}
 	data.Args = args.Args
+	data.ArgsEncoded = args.ArgsEncoded
 	return &data
 }
 

--- a/airgap/txargs_marshall.go
+++ b/airgap/txargs_marshall.go
@@ -26,7 +26,7 @@ type txArgsRawData struct {
 	To          *common.Address `json:"to,omitempty"`
 	Method      *string         `json:"method,omitempty"`
 	Args        []interface{}   `json:"args,omitempty"`
-	ArgsEncoded *bool           `json:"args_encoded,omitempty"`
+	ArgsEncoded bool            `json:"args_encoded,omitempty"`
 }
 
 type callParamsRawData struct {


### PR DESCRIPTION
In order to support transaction construction for arbitrary contract calls, we're making the following changes:

The /construction/metadata endpoint will now, given the following arguments...
```
- from:   <caller address>              (string)    // "0xabcd...."
- to:     <contract address>            (string)    // "0xabcd...."
- method: <method signature>            (string)    // "deploy(uint8,address,bytes32)"
- args:   [<already_encoded_args_data>] ([1]string) // ["0xabcd...."] if args_encoded is true
          OR
          [<arg1>, <arg2>, ...]         ([]string)  // ["5","0xabcd...",...] if args_encoded is false
- args_encoded:                         (bool)
- amount: <amount>                      (int)
```
...return the corresponding valid TxMetadata object.

This behavior aligns with other EVM-compatible rosetta implementations (https://github.com/Inphi/optimism-rosetta/pull/103, https://github.com/maticnetwork/polygon-rosetta/pull/46), as well as [rosetta-geth-sdk](https://github.com/jiangchuan-he-cb/rosetta-geth-sdk/blob/9e9eb9d1c3310ad5eee943c0b6856b186b236e2a/services/construction/contract_call_data.go#L35), which all support both argument encoding formats.

To support this functionality while reducing internal changes, CeloMethod now additionally supports 'unregistered' methods, which are identified by method signature.
