### PR TITLE
[fix] support checking complex method signature

### DIFF
--- a/airgap/method_registry_test.go
+++ b/airgap/method_registry_test.go
@@ -22,6 +22,7 @@ func Test_validateMethodSignature(t *testing.T) {
 		methodSig string
 		wantErr   bool
 	}{
+		{name: "no method name", methodSig: "()", wantErr: true},
 		{name: "valid signature with no args", methodSig: "noArgs()", wantErr: false},
 		{name: "valid signature with one arg", methodSig: "deploy(address)", wantErr: false},
 		{name: "valid signature with multiple args", methodSig: "deploy(address,uint8,bytes16,address)", wantErr: false},

--- a/airgap/method_registry_test.go
+++ b/airgap/method_registry_test.go
@@ -25,9 +25,14 @@ func Test_validateMethodSignature(t *testing.T) {
 		{name: "valid signature with no args", methodSig: "noArgs()", wantErr: false},
 		{name: "valid signature with one arg", methodSig: "deploy(address)", wantErr: false},
 		{name: "valid signature with multiple args", methodSig: "deploy(address,uint8,bytes16,address)", wantErr: false},
+		{name: "valid signature with nested args", methodSig: "batchTransfer((address,(address,(address,uint256)[])[])[],uint256)", wantErr: false},
 		{name: "signature with invalid arg type", methodSig: "batchTransfer(DepositWalletTransfer[])", wantErr: true},
 		{name: "closing parenthesis only", methodSig: "noArgs)", wantErr: true},
 		{name: "open parenthesis only", methodSig: "noArgs(", wantErr: true},
+		{name: "missing closing bracket in the args", methodSig: "batchTransfer(bytes[)", wantErr: true},
+		{name: "mismatch parenthesis in the args", methodSig: "batchTransfer(bytes[))", wantErr: true},
+		{name: "missing open bracket in the args", methodSig: "batchTransfer(bytes])", wantErr: true},
+		{name: "missing closing bracket in the nested args", methodSig: "batchTransfer((address,(address,(address,uint256)[)[])[],uint256)", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What
The previous method signature check function is not able to handle complex method signature (e.g nested arguments). Because of that, the rosetta node is not able to process contract call method containing nested arguments. 

This pr fixed this issue with updated solution below
1. check method name to ensure it's not empty
2. check the method contains valid parentheses by using the classic valid parentheses check algorithm (with stack).
3. extract the parameter types into an array and perform the type check.


### Tests
* Added some more unit tests
* End to End tests