### PR TITLE
Send Ethereum style transactions

### DIFF
--- a/airgap/api.go
+++ b/airgap/api.go
@@ -130,14 +130,11 @@ type TxMetadata struct {
 
 func (tm *TxMetadata) AsCallMessage() ethereum.CallMsg {
 	return ethereum.CallMsg{
-		From:                tm.From,
-		GatewayFee:          tm.GatewayFee,
-		GatewayFeeRecipient: tm.GatewayFeeRecipient,
-		GasPrice:            tm.GasPrice,
-		To:                  &tm.To,
-		Data:                tm.Data,
-		Value:               tm.Value,
-		FeeCurrency:         tm.FeeCurrency,
+		From:     tm.From,
+		GasPrice: tm.GasPrice,
+		To:       &tm.To,
+		Data:     tm.Data,
+		Value:    tm.Value,
 	}
 }
 
@@ -151,15 +148,12 @@ func (tx *Transaction) Signed() bool {
 }
 
 func (tx *Transaction) AsGethTransaction() (*types.Transaction, error) {
-	gethTx := types.NewCeloTransaction(
+	gethTx := types.NewTransaction(
 		tx.Nonce,
 		tx.To,
 		tx.Value,
 		tx.Gas,
 		tx.GasPrice,
-		tx.FeeCurrency,
-		tx.GatewayFeeRecipient,
-		tx.GatewayFee,
 		tx.Data,
 	)
 	if tx.Signed() {
@@ -214,9 +208,6 @@ func (tx *Transaction) Deserialize(data []byte, chainId *big.Int) error {
 	tx.TxMetadata = &TxMetadata{}
 	tx.Nonce = gethTx.Nonce()
 	tx.GasPrice = gethTx.GasPrice()
-	tx.GatewayFee = gethTx.GatewayFee()
-	tx.GatewayFeeRecipient = gethTx.GatewayFeeRecipient()
-	tx.FeeCurrency = gethTx.FeeCurrency()
 	tx.To = *gethTx.To()
 	tx.Data = gethTx.Data()
 	tx.Value = gethTx.Value()

--- a/airgap/api_test.go
+++ b/airgap/api_test.go
@@ -37,22 +37,17 @@ func TestTransaction(t *testing.T) {
 	_, fromAddr, err := client.Derive(privKey)
 	Ω(err).ShouldNot(HaveOccurred())
 
-	addr2 := common.HexToAddress("0x2222")
-	addr3 := common.HexToAddress("0x3333")
 	newTx := func() *Transaction {
 		return &Transaction{
 			TxMetadata: &TxMetadata{
-				From:                *fromAddr,
-				Nonce:               3,
-				GasPrice:            big.NewInt(111),
-				GatewayFeeRecipient: &addr2,
-				GatewayFee:          big.NewInt(222),
-				FeeCurrency:         &addr3,
-				To:                  common.HexToAddress("0x4444"),
-				Data:                []byte{1, 2, 3, 4},
-				Value:               big.NewInt(4444),
-				Gas:                 4,
-				ChainId:             big.NewInt(42220),
+				From:     *fromAddr,
+				Nonce:    3,
+				GasPrice: big.NewInt(111),
+				To:       common.HexToAddress("0x4444"),
+				Data:     []byte{1, 2, 3, 4},
+				Value:    big.NewInt(4444),
+				Gas:      4,
+				ChainId:  big.NewInt(42220),
 			},
 		}
 	}
@@ -84,11 +79,11 @@ func TestTransaction(t *testing.T) {
 		signedTxRaw, err := signedTx.Serialize()
 		Ω(err).ShouldNot(HaveOccurred())
 
-		var desrializedTx Transaction
-		err = desrializedTx.Deserialize(signedTxRaw, tx.ChainId)
+		var deserializedTx Transaction
+		err = deserializedTx.Deserialize(signedTxRaw, tx.ChainId)
 		Ω(err).ShouldNot(HaveOccurred())
 
-		Ω(desrializedTx).Should(Equal(*signedTx))
+		Ω(deserializedTx).Should(Equal(*signedTx))
 	})
 
 }


### PR DESCRIPTION
Don't send deprecated legacy Celo transactions, instead send Ethereum compatible transactions.

This doesn't change external APIs.